### PR TITLE
Implement decision state machine

### DIFF
--- a/cadence/_internal/__init__.py
+++ b/cadence/_internal/__init__.py
@@ -1,0 +1,10 @@
+"""Private implementation details for the Cadence Python client.
+
+Modules in this package are not part of the public API surface and may change
+without notice. Public callers should import from packages like `cadence.worker`,
+`cadence.workflow`, and `cadence.activity` instead.
+"""
+
+__all__: list[str] = []
+
+

--- a/cadence/_internal/decision_state_machine.py
+++ b/cadence/_internal/decision_state_machine.py
@@ -1,0 +1,603 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Dict, List, Optional, Sequence
+
+# Protobuf API types
+from cadence.api.v1 import (
+    decision_pb2 as decision,
+    history_pb2 as history,
+    common_pb2 as common,
+)
+
+
+class MachineStatus(Enum):
+    """Lifecycle states for a decision-producing state machine instance."""
+
+    CREATED = auto()
+    SCHEDULED = auto()
+    STARTED = auto()
+    COMPLETED = auto()
+    FAILED = auto()
+    CANCELED = auto()
+    TIMED_OUT = auto()
+
+
+class DecisionState(Enum):
+    CREATED = 0
+    DECISION_SENT = 1
+    CANCELED_BEFORE_INITIATED = 2
+    INITIATED = 3
+    STARTED = 4
+    CANCELED_AFTER_INITIATED = 5
+    CANCELED_AFTER_STARTED = 6
+    CANCELLATION_DECISION_SENT = 7
+    COMPLETED_AFTER_CANCELLATION_DECISION_SENT = 8
+    COMPLETED = 9
+
+
+class DecisionType(Enum):
+    ACTIVITY = 0
+    CHILD_WORKFLOW = 1
+    CANCELLATION = 2
+    MARKER = 3
+    TIMER = 4
+    SIGNAL = 5
+    UPSERT_SEARCH_ATTRIBUTES = 6
+
+
+# Event name constants (used by Go state machine; provided for parity/testing/logs)
+EVENT_CANCEL = "cancel"
+EVENT_DECISION_SENT = "handleDecisionSent"
+EVENT_INITIATED = "handleInitiatedEvent"
+EVENT_INITIATION_FAILED = "handleInitiationFailedEvent"
+EVENT_STARTED = "handleStartedEvent"
+EVENT_COMPLETION = "handleCompletionEvent"
+EVENT_CANCEL_INITIATED = "handleCancelInitiatedEvent"
+EVENT_CANCEL_FAILED = "handleCancelFailedEvent"
+EVENT_CANCELED = "handleCanceledEvent"
+
+
+# Marker names
+SIDE_EFFECT_MARKER_NAME = "SideEffect"
+VERSION_MARKER_NAME = "Version"
+LOCAL_ACTIVITY_MARKER_NAME = "LocalActivity"
+MUTABLE_SIDE_EFFECT_MARKER_NAME = "MutableSideEffect"
+
+
+def decision_state_to_string(state: DecisionState) -> str:
+    mapping = {
+        DecisionState.CREATED: "Created",
+        DecisionState.DECISION_SENT: "DecisionSent",
+        DecisionState.CANCELED_BEFORE_INITIATED: "CanceledBeforeInitiated",
+        DecisionState.INITIATED: "Initiated",
+        DecisionState.STARTED: "Started",
+        DecisionState.CANCELED_AFTER_INITIATED: "CanceledAfterInitiated",
+        DecisionState.CANCELED_AFTER_STARTED: "CanceledAfterStarted",
+        DecisionState.CANCELLATION_DECISION_SENT: "CancellationDecisionSent",
+        DecisionState.COMPLETED_AFTER_CANCELLATION_DECISION_SENT: "CompletedAfterCancellationDecisionSent",
+        DecisionState.COMPLETED: "Completed",
+    }
+    return mapping.get(state, "Unknown")
+
+
+def decision_type_to_string(dt: DecisionType) -> str:
+    mapping = {
+        DecisionType.ACTIVITY: "Activity",
+        DecisionType.CHILD_WORKFLOW: "ChildWorkflow",
+        DecisionType.CANCELLATION: "Cancellation",
+        DecisionType.MARKER: "Marker",
+        DecisionType.TIMER: "Timer",
+        DecisionType.SIGNAL: "Signal",
+        DecisionType.UPSERT_SEARCH_ATTRIBUTES: "UpsertSearchAttributes",
+    }
+    return mapping.get(dt, "Unknown")
+
+
+@dataclass(frozen=True)
+class DecisionId:
+    decision_type: DecisionType
+    id: str
+
+    def __str__(self) -> str: 
+        return f"DecisionType: {decision_type_to_string(self.decision_type)}, ID: {self.id}"
+
+
+class DecisionStateMachine:
+    """Base class for state machines that may emit one or more decisions over time.
+
+    Subclasses are responsible for mapping workflow history events into state
+    transitions and producing the next set of decisions when queried.
+    """
+
+    def get_id(self) -> str:
+        raise NotImplementedError
+
+    # Typed handlers (Go-parity naming semantics)
+    def handle_initiated_event(self, event: history.HistoryEvent) -> None:
+        pass
+
+    def handle_started_event(self, event: history.HistoryEvent) -> None:
+        pass
+
+    def handle_completion_event(self, event: history.HistoryEvent) -> None:
+        pass
+
+    def handle_initiation_failed_event(self, event: history.HistoryEvent) -> None:
+        pass
+
+    def handle_cancel_initiated_event(self, event: history.HistoryEvent) -> None:
+        pass
+
+    def handle_cancel_failed_event(self, event: history.HistoryEvent) -> None:
+        pass
+
+    def handle_canceled_event(self, event: history.HistoryEvent) -> None:
+        pass
+
+    def collect_pending_decisions(self) -> List[decision.Decision]:
+        """Return any decisions that should be emitted now.
+
+        Implementations must be idempotent: repeated calls without intervening
+        state changes should return the same results (typically empty if already
+        emitted for current state).
+        """
+        raise NotImplementedError
+
+
+# Activity
+
+
+@dataclass
+class ActivityDecisionMachine(DecisionStateMachine):
+    """Tracks lifecycle of a single activity execution by activity_id."""
+
+    activity_id: str
+    schedule_attributes: decision.ScheduleActivityTaskDecisionAttributes
+    status: MachineStatus = MachineStatus.CREATED
+    scheduled_event_id: Optional[int] = None
+    started_event_id: Optional[int] = None
+    _schedule_emitted: bool = False
+    _cancel_requested: bool = False
+    _cancel_emitted: bool = False
+
+    def get_id(self) -> str:
+        return self.activity_id
+
+    def handle_initiated_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "activity_task_scheduled_event_attributes", None)
+        if a is not None and a.activity_id == self.activity_id:
+            self.status = MachineStatus.SCHEDULED
+            self.scheduled_event_id = event.event_id
+
+    def handle_started_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "activity_task_started_event_attributes", None)
+        if a is not None and self.scheduled_event_id and a.scheduled_event_id == self.scheduled_event_id:
+            self.status = MachineStatus.STARTED
+            self.started_event_id = event.event_id
+
+    def handle_completion_event(self, event: history.HistoryEvent) -> None:
+        if getattr(event, "activity_task_completed_event_attributes", None) is not None:
+            a = event.activity_task_completed_event_attributes
+            if self.scheduled_event_id and a.scheduled_event_id == self.scheduled_event_id:
+                self.status = MachineStatus.COMPLETED
+        elif getattr(event, "activity_task_failed_event_attributes", None) is not None:
+            a = event.activity_task_failed_event_attributes
+            if self.scheduled_event_id and a.scheduled_event_id == self.scheduled_event_id:
+                self.status = MachineStatus.FAILED
+        elif getattr(event, "activity_task_timed_out_event_attributes", None) is not None:
+            a = event.activity_task_timed_out_event_attributes
+            if self.scheduled_event_id and a.scheduled_event_id == self.scheduled_event_id:
+                self.status = MachineStatus.TIMED_OUT
+
+    def handle_cancel_initiated_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "activity_task_cancel_requested_event_attributes", None)
+        if a is not None and a.activity_id == self.activity_id:
+            self._cancel_requested = True
+
+    def handle_cancel_failed_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "request_cancel_activity_task_failed_event_attributes", None)
+        if a is not None and a.activity_id == self.activity_id:
+            # allow future cancel retry
+            self._cancel_emitted = False
+
+    def handle_canceled_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "activity_task_canceled_event_attributes", None)
+        if a is not None and self.scheduled_event_id and a.scheduled_event_id == self.scheduled_event_id:
+            self.status = MachineStatus.CANCELED
+
+    def collect_pending_decisions(self) -> List[decision.Decision]:
+        decisions: List[decision.Decision] = []
+
+        if self.status is MachineStatus.CREATED and not self._schedule_emitted:
+            # Emit initial schedule decision
+            decisions.append(
+                decision.Decision(
+                    schedule_activity_task_decision_attributes=self.schedule_attributes
+                )
+            )
+            self._schedule_emitted = True
+
+        if self._cancel_requested and not self._cancel_emitted and not self.is_terminal():
+            # Emit cancel request
+            decisions.append(
+                decision.Decision(
+                    request_cancel_activity_task_decision_attributes=
+                    decision.RequestCancelActivityTaskDecisionAttributes(
+                        activity_id=self.activity_id
+                    )
+                )
+            )
+            self._cancel_emitted = True
+
+        return decisions
+
+    def request_cancel(self) -> None:
+        if not self.is_terminal():
+            self._cancel_requested = True
+
+    def is_terminal(self) -> bool:
+        return self.status in (
+            MachineStatus.COMPLETED,
+            MachineStatus.FAILED,
+            MachineStatus.CANCELED,
+            MachineStatus.TIMED_OUT,
+        )
+
+
+# Timer
+
+
+@dataclass
+class TimerDecisionMachine(DecisionStateMachine):
+    """Tracks lifecycle of a single workflow timer by timer_id."""
+
+    timer_id: str
+    start_attributes: decision.StartTimerDecisionAttributes
+    status: MachineStatus = MachineStatus.CREATED
+    started_event_id: Optional[int] = None
+    _start_emitted: bool = False
+    _cancel_requested: bool = False
+    _cancel_emitted: bool = False
+
+    def get_id(self) -> str:
+        return self.timer_id
+
+    def handle_initiated_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "timer_started_event_attributes", None)
+        if a is not None and a.timer_id == self.timer_id:
+            self.status = MachineStatus.SCHEDULED
+            self.started_event_id = event.event_id
+
+    def handle_started_event(self, event: history.HistoryEvent) -> None:
+        # Timers don't have a separate started beyond TimerStarted
+        pass
+
+    def handle_completion_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "timer_fired_event_attributes", None)
+        if a is not None and self.started_event_id and a.started_event_id == self.started_event_id:
+            self.status = MachineStatus.COMPLETED
+
+    def handle_canceled_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "timer_canceled_event_attributes", None)
+        if a is not None and self.started_event_id and a.started_event_id == self.started_event_id:
+            self.status = MachineStatus.CANCELED
+
+    def handle_cancel_failed_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "cancel_timer_failed_event_attributes", None)
+        if a is not None and a.timer_id == self.timer_id:
+            self._cancel_emitted = False
+
+    def collect_pending_decisions(self) -> List[decision.Decision]:
+        decisions: List[decision.Decision] = []
+
+        if self.status is MachineStatus.CREATED and not self._start_emitted:
+            decisions.append(
+                decision.Decision(
+                    start_timer_decision_attributes=self.start_attributes
+                )
+            )
+            self._start_emitted = True
+
+        if self._cancel_requested and not self._cancel_emitted and not self.is_terminal():
+            decisions.append(
+                decision.Decision(
+                    cancel_timer_decision_attributes=decision.CancelTimerDecisionAttributes(
+                        timer_id=self.timer_id
+                    )
+                )
+            )
+            self._cancel_emitted = True
+
+        return decisions
+
+    def request_cancel(self) -> None:
+        if not self.is_terminal():
+            self._cancel_requested = True
+
+    def is_terminal(self) -> bool:
+        return self.status in (
+            MachineStatus.COMPLETED,
+            MachineStatus.CANCELED,
+            MachineStatus.FAILED,
+            MachineStatus.TIMED_OUT,
+        )
+
+
+# Child Workflow
+
+
+@dataclass
+class ChildWorkflowDecisionMachine(DecisionStateMachine):
+    """Tracks lifecycle of a child workflow start/cancel by client-provided id.
+
+    Cadence history references child workflows via initiated event IDs. For simplicity,
+    we track by a client-provided identifier (e.g., a unique string) that must map
+    to attributes.worklow_id when possible.
+    """
+
+    client_id: str
+    start_attributes: decision.StartChildWorkflowExecutionDecisionAttributes
+    status: MachineStatus = MachineStatus.CREATED
+    initiated_event_id: Optional[int] = None
+    started_event_id: Optional[int] = None
+    _start_emitted: bool = False
+    _cancel_requested: bool = False
+    _cancel_emitted: bool = False
+
+    def get_id(self) -> str:
+        return self.client_id
+
+    def handle_initiated_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "start_child_workflow_execution_initiated_event_attributes", None)
+        if a is not None and a.workflow_id == self.start_attributes.workflow_id:
+            self.status = MachineStatus.SCHEDULED
+            self.initiated_event_id = event.event_id
+
+    def handle_started_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "child_workflow_execution_started_event_attributes", None)
+        if a is not None and self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
+            self.status = MachineStatus.STARTED
+            self.started_event_id = event.event_id
+
+    def handle_completion_event(self, event: history.HistoryEvent) -> None:
+        if getattr(event, "child_workflow_execution_completed_event_attributes", None) is not None:
+            a = event.child_workflow_execution_completed_event_attributes
+            if self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
+                self.status = MachineStatus.COMPLETED
+        elif getattr(event, "child_workflow_execution_failed_event_attributes", None) is not None:
+            a = event.child_workflow_execution_failed_event_attributes
+            if self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
+                self.status = MachineStatus.FAILED
+        elif getattr(event, "child_workflow_execution_timed_out_event_attributes", None) is not None:
+            a = event.child_workflow_execution_timed_out_event_attributes
+            if self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
+                self.status = MachineStatus.TIMED_OUT
+
+    def handle_canceled_event(self, event: history.HistoryEvent) -> None:
+        if getattr(event, "child_workflow_execution_canceled_event_attributes", None) is not None:
+            a = event.child_workflow_execution_canceled_event_attributes
+            if self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
+                self.status = MachineStatus.CANCELED
+        elif getattr(event, "child_workflow_execution_terminated_event_attributes", None) is not None:
+            a = event.child_workflow_execution_terminated_event_attributes
+            if self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
+                self.status = MachineStatus.CANCELED
+
+    def handle_initiation_failed_event(self, event: history.HistoryEvent) -> None:
+        a = getattr(event, "start_child_workflow_execution_failed_event_attributes", None)
+        if a is not None and (
+            (hasattr(a, "initiated_event_id") and self.initiated_event_id and a.initiated_event_id == self.initiated_event_id)
+            or a.workflow_id == self.start_attributes.workflow_id
+        ):
+            self.status = MachineStatus.FAILED
+
+    def collect_pending_decisions(self) -> List[decision.Decision]:
+        decisions: List[decision.Decision] = []
+
+        if self.status is MachineStatus.CREATED and not self._start_emitted:
+            decisions.append(
+                decision.Decision(
+                    start_child_workflow_execution_decision_attributes=self.start_attributes
+                )
+            )
+            self._start_emitted = True
+
+        if self._cancel_requested and not self._cancel_emitted and not self.is_terminal():
+            # Request cancel of the child workflow via external cancel with child_workflow_only
+            decisions.append(
+                decision.Decision(
+                    request_cancel_external_workflow_execution_decision_attributes=
+                    decision.RequestCancelExternalWorkflowExecutionDecisionAttributes(
+                        domain=self.start_attributes.domain,
+                        workflow_execution=common.WorkflowExecution(
+                            workflow_id=self.start_attributes.workflow_id
+                        ),
+                        child_workflow_only=True,
+                    )
+                )
+            )
+            self._cancel_emitted = True
+        return decisions
+
+    def request_cancel(self) -> None:
+        if not self.is_terminal():
+            self._cancel_requested = True
+
+    def is_terminal(self) -> bool:
+        return self.status in (
+            MachineStatus.COMPLETED,
+            MachineStatus.FAILED,
+            MachineStatus.CANCELED,
+            MachineStatus.TIMED_OUT,
+        )
+
+
+@dataclass
+class DecisionManager:
+    """Aggregates multiple decision state machines and coordinates decisions.
+
+    Typical flow per decision task:
+    - Instantiate/update state machines based on application intent and incoming history
+    - Call collect_pending_decisions() to build the decisions list
+    - Submit via RespondDecisionTaskCompleted
+    """
+
+    activities: Dict[str, ActivityDecisionMachine] = field(default_factory=dict)
+    timers: Dict[str, TimerDecisionMachine] = field(default_factory=dict)
+    children: Dict[str, ChildWorkflowDecisionMachine] = field(default_factory=dict)
+
+    # ----- Activity API -----
+
+    def schedule_activity(
+        self, activity_id: str, attrs: decision.ScheduleActivityTaskDecisionAttributes
+    ) -> ActivityDecisionMachine:
+        machine = self.activities.get(activity_id)
+        if machine is None or machine.is_terminal():
+            machine = ActivityDecisionMachine(activity_id=activity_id, schedule_attributes=attrs)
+            self.activities[activity_id] = machine
+        return machine
+
+    def request_cancel_activity(self, activity_id: str) -> None:
+        machine = self.activities.get(activity_id)
+        if machine is not None:
+            machine.request_cancel()
+
+    # ----- Timer API -----
+
+    def start_timer(
+        self, timer_id: str, attrs: decision.StartTimerDecisionAttributes
+    ) -> TimerDecisionMachine:
+        machine = self.timers.get(timer_id)
+        if machine is None or machine.is_terminal():
+            machine = TimerDecisionMachine(timer_id=timer_id, start_attributes=attrs)
+            self.timers[timer_id] = machine
+        return machine
+
+    def cancel_timer(self, timer_id: str) -> None:
+        machine = self.timers.get(timer_id)
+        if machine is not None:
+            machine.request_cancel()
+
+    # ----- Child Workflow API -----
+
+    def start_child_workflow(
+        self, client_id: str, attrs: decision.StartChildWorkflowExecutionDecisionAttributes
+    ) -> ChildWorkflowDecisionMachine:
+        machine = self.children.get(client_id)
+        if machine is None or machine.is_terminal():
+            machine = ChildWorkflowDecisionMachine(client_id=client_id, start_attributes=attrs)
+            self.children[client_id] = machine
+        return machine
+
+    def cancel_child_workflow(self, client_id: str) -> None:
+        machine = self.children.get(client_id)
+        if machine is not None:
+            machine.request_cancel()
+
+    # ----- History routing -----
+
+    def handle_history_event(self, event: history.HistoryEvent) -> None:
+        """Dispatch history event to typed handlers, Go-style."""
+        attr = event.WhichOneof("attributes")
+
+        # Initiated
+        if attr in (
+            "activity_task_scheduled_event_attributes",
+            "timer_started_event_attributes",
+            "start_child_workflow_execution_initiated_event_attributes",
+        ):
+            for m in list(self.activities.values()):
+                m.handle_initiated_event(event)
+            for m in list(self.timers.values()):
+                m.handle_initiated_event(event)
+            for m in list(self.children.values()):
+                m.handle_initiated_event(event)
+            return
+
+        # Started
+        if attr in (
+            "activity_task_started_event_attributes",
+            "child_workflow_execution_started_event_attributes",
+        ):
+            for m in list(self.activities.values()):
+                m.handle_started_event(event)
+            for m in list(self.children.values()):
+                m.handle_started_event(event)
+            return
+
+        # Completion-like
+        if attr in (
+            "activity_task_completed_event_attributes",
+            "activity_task_failed_event_attributes",
+            "activity_task_timed_out_event_attributes",
+            "timer_fired_event_attributes",
+            "child_workflow_execution_completed_event_attributes",
+            "child_workflow_execution_failed_event_attributes",
+            "child_workflow_execution_timed_out_event_attributes",
+        ):
+            for m in list(self.activities.values()):
+                m.handle_completion_event(event)
+            for m in list(self.timers.values()):
+                m.handle_completion_event(event)
+            for m in list(self.children.values()):
+                m.handle_completion_event(event)
+            return
+
+        # Cancel-initiated / cancel-failed / canceled
+        if attr in ("activity_task_cancel_requested_event_attributes",):
+            for m in list(self.activities.values()):
+                m.handle_cancel_initiated_event(event)
+            return
+
+        if attr in (
+            "request_cancel_activity_task_failed_event_attributes",
+            "cancel_timer_failed_event_attributes",
+        ):
+            for m in list(self.activities.values()):
+                m.handle_cancel_failed_event(event)
+            for m in list(self.timers.values()):
+                m.handle_cancel_failed_event(event)
+            return
+
+        if attr in (
+            "activity_task_canceled_event_attributes",
+            "timer_canceled_event_attributes",
+            "child_workflow_execution_canceled_event_attributes",
+            "child_workflow_execution_terminated_event_attributes",
+        ):
+            for m in list(self.activities.values()):
+                m.handle_canceled_event(event)
+            for m in list(self.timers.values()):
+                m.handle_canceled_event(event)
+            for m in list(self.children.values()):
+                m.handle_canceled_event(event)
+            return
+
+        # Initiation failed
+        if attr in ("start_child_workflow_execution_failed_event_attributes",):
+            for m in list(self.children.values()):
+                m.handle_initiation_failed_event(event)
+            return
+
+    # ----- Decision aggregation -----
+
+    def collect_pending_decisions(self) -> List[decision.Decision]:
+        decisions: List[decision.Decision] = []
+
+        # Activities
+        for machine in list(self.activities.values()):
+            decisions.extend(machine.collect_pending_decisions())
+
+        # Timers
+        for machine in list(self.timers.values()):
+            decisions.extend(machine.collect_pending_decisions())
+
+        # Children
+        for machine in list(self.children.values()):
+            decisions.extend(machine.collect_pending_decisions())
+
+        return decisions
+
+

--- a/cadence/_internal/decision_state_machine.py
+++ b/cadence/_internal/decision_state_machine.py
@@ -12,19 +12,9 @@ from cadence.api.v1 import (
 )
 
 
-class MachineStatus(Enum):
+class DecisionState(Enum):
     """Lifecycle states for a decision-producing state machine instance."""
 
-    CREATED = auto()
-    SCHEDULED = auto()
-    STARTED = auto()
-    COMPLETED = auto()
-    FAILED = auto()
-    CANCELED = auto()
-    TIMED_OUT = auto()
-
-
-class DecisionState(Enum):
     CREATED = 0
     DECISION_SENT = 1
     CANCELED_BEFORE_INITIATED = 2
@@ -35,6 +25,28 @@ class DecisionState(Enum):
     CANCELLATION_DECISION_SENT = 7
     COMPLETED_AFTER_CANCELLATION_DECISION_SENT = 8
     COMPLETED = 9
+    FAILED = 10
+    CANCELED = 11
+    TIMED_OUT = 12
+
+    @classmethod
+    def to_string(cls, state: DecisionState) -> str:
+        mapping = {
+            DecisionState.CREATED: "Created",
+            DecisionState.DECISION_SENT: "DecisionSent",
+            DecisionState.CANCELED_BEFORE_INITIATED: "CanceledBeforeInitiated",
+            DecisionState.INITIATED: "Initiated",
+            DecisionState.STARTED: "Started",
+            DecisionState.CANCELED_AFTER_INITIATED: "CanceledAfterInitiated",
+            DecisionState.CANCELED_AFTER_STARTED: "CanceledAfterStarted",
+            DecisionState.CANCELLATION_DECISION_SENT: "CancellationDecisionSent",
+            DecisionState.COMPLETED_AFTER_CANCELLATION_DECISION_SENT: "CompletedAfterCancellationDecisionSent",
+            DecisionState.COMPLETED: "Completed",
+            DecisionState.FAILED: "Failed",
+            DecisionState.CANCELED: "Canceled",
+            DecisionState.TIMED_OUT: "TimedOut",
+        }
+        return mapping.get(state, "Unknown")
 
 
 class DecisionType(Enum):
@@ -46,53 +58,18 @@ class DecisionType(Enum):
     SIGNAL = 5
     UPSERT_SEARCH_ATTRIBUTES = 6
 
-
-# Event name constants (used by Go state machine; provided for parity/testing/logs)
-EVENT_CANCEL = "cancel"
-EVENT_DECISION_SENT = "handleDecisionSent"
-EVENT_INITIATED = "handleInitiatedEvent"
-EVENT_INITIATION_FAILED = "handleInitiationFailedEvent"
-EVENT_STARTED = "handleStartedEvent"
-EVENT_COMPLETION = "handleCompletionEvent"
-EVENT_CANCEL_INITIATED = "handleCancelInitiatedEvent"
-EVENT_CANCEL_FAILED = "handleCancelFailedEvent"
-EVENT_CANCELED = "handleCanceledEvent"
-
-
-# Marker names
-SIDE_EFFECT_MARKER_NAME = "SideEffect"
-VERSION_MARKER_NAME = "Version"
-LOCAL_ACTIVITY_MARKER_NAME = "LocalActivity"
-MUTABLE_SIDE_EFFECT_MARKER_NAME = "MutableSideEffect"
-
-
-def decision_state_to_string(state: DecisionState) -> str:
-    mapping = {
-        DecisionState.CREATED: "Created",
-        DecisionState.DECISION_SENT: "DecisionSent",
-        DecisionState.CANCELED_BEFORE_INITIATED: "CanceledBeforeInitiated",
-        DecisionState.INITIATED: "Initiated",
-        DecisionState.STARTED: "Started",
-        DecisionState.CANCELED_AFTER_INITIATED: "CanceledAfterInitiated",
-        DecisionState.CANCELED_AFTER_STARTED: "CanceledAfterStarted",
-        DecisionState.CANCELLATION_DECISION_SENT: "CancellationDecisionSent",
-        DecisionState.COMPLETED_AFTER_CANCELLATION_DECISION_SENT: "CompletedAfterCancellationDecisionSent",
-        DecisionState.COMPLETED: "Completed",
-    }
-    return mapping.get(state, "Unknown")
-
-
-def decision_type_to_string(dt: DecisionType) -> str:
-    mapping = {
-        DecisionType.ACTIVITY: "Activity",
-        DecisionType.CHILD_WORKFLOW: "ChildWorkflow",
-        DecisionType.CANCELLATION: "Cancellation",
-        DecisionType.MARKER: "Marker",
-        DecisionType.TIMER: "Timer",
-        DecisionType.SIGNAL: "Signal",
-        DecisionType.UPSERT_SEARCH_ATTRIBUTES: "UpsertSearchAttributes",
-    }
-    return mapping.get(dt, "Unknown")
+    @classmethod
+    def to_string(cls, dt: DecisionType) -> str:
+        mapping = {
+            DecisionType.ACTIVITY: "Activity",
+            DecisionType.CHILD_WORKFLOW: "ChildWorkflow",
+            DecisionType.CANCELLATION: "Cancellation",
+            DecisionType.MARKER: "Marker",
+            DecisionType.TIMER: "Timer",
+            DecisionType.SIGNAL: "Signal",
+            DecisionType.UPSERT_SEARCH_ATTRIBUTES: "UpsertSearchAttributes",
+        }
+        return mapping.get(dt, "Unknown")
 
 
 @dataclass(frozen=True)
@@ -100,11 +77,13 @@ class DecisionId:
     decision_type: DecisionType
     id: str
 
-    def __str__(self) -> str: 
-        return f"DecisionType: {decision_type_to_string(self.decision_type)}, ID: {self.id}"
+    def __str__(self) -> str:
+        return (
+            f"DecisionType: {DecisionType.to_string(self.decision_type)}, ID: {self.id}"
+        )
 
 
-class DecisionStateMachine:
+class BaseDecisionStateMachine:
     """Base class for state machines that may emit one or more decisions over time.
 
     Subclasses are responsible for mapping workflow history events into state
@@ -114,27 +93,139 @@ class DecisionStateMachine:
     def get_id(self) -> str:
         raise NotImplementedError
 
-    # Typed handlers (Go-parity naming semantics)
+    # Common patterns that can be overridden by subclasses
+    def _get_initiated_event_attr_name(self) -> str:
+        """Return the protobuf attribute name for initiated events."""
+        raise NotImplementedError
+
+    def _get_started_event_attr_name(self) -> str:
+        """Return the protobuf attribute name for started events."""
+        raise NotImplementedError
+
+    def _get_completion_event_attr_names(self) -> List[str]:
+        """Return the protobuf attribute names for completion events."""
+        raise NotImplementedError
+
+    def _get_cancel_initiated_event_attr_name(self) -> str:
+        """Return the protobuf attribute name for cancel initiated events."""
+        raise NotImplementedError
+
+    def _get_cancel_failed_event_attr_name(self) -> str:
+        """Return the protobuf attribute name for cancel failed events."""
+        raise NotImplementedError
+
+    def _get_canceled_event_attr_names(self) -> List[str]:
+        """Return the protobuf attribute names for canceled events."""
+        raise NotImplementedError
+
+    def _get_id_field_name(self) -> str:
+        """Return the field name used to identify this decision in events."""
+        raise NotImplementedError
+
+    def _get_event_id_field_name(self) -> str:
+        """Return the field name used to track event IDs."""
+        return "scheduled_event_id"  # Default, can be overridden
+
+    def _should_handle_event(
+        self, event: history.HistoryEvent, attr_name: str, id_field: str
+    ) -> bool:
+        """Generic check if this event should be handled by this machine."""
+        attr = getattr(event, attr_name, None)
+        if attr is None:
+            return False
+
+        # Check if the ID matches
+        event_id = getattr(attr, id_field, None)
+        machine_id = getattr(self, self._get_id_field_name(), None)
+        return event_id == machine_id
+
+    def _should_handle_event_by_event_id(
+        self, event: history.HistoryEvent, attr_name: str, event_id_field: str
+    ) -> bool:
+        """Generic check if this event should be handled by this machine based on event ID."""
+        attr = getattr(event, attr_name, None)
+        if attr is None:
+            return False
+
+        # Check if the event ID matches our tracked event ID
+        event_id = getattr(attr, event_id_field, None)
+        tracked_event_id = getattr(self, self._get_event_id_field_name(), None)
+        return event_id == tracked_event_id
+
+    # Typed handlers with generic implementations
     def handle_initiated_event(self, event: history.HistoryEvent) -> None:
-        pass
+        """Generic initiated event handler."""
+        attr_name = self._get_initiated_event_attr_name()
+        id_field = self._get_id_field_name()
+
+        if self._should_handle_event(event, attr_name, id_field):
+            self.status = DecisionState.INITIATED
+            # Store the event ID for future reference
+            event_id_field = self._get_event_id_field_name()
+            setattr(self, event_id_field, event.event_id)
 
     def handle_started_event(self, event: history.HistoryEvent) -> None:
-        pass
+        """Generic started event handler."""
+        attr_name = self._get_started_event_attr_name()
+        event_id_field = self._get_event_id_field_name()
+
+        if self._should_handle_event_by_event_id(event, attr_name, event_id_field):
+            self.status = DecisionState.STARTED
+            # Store the started event ID if needed
+            if hasattr(self, "started_event_id"):
+                self.started_event_id = event.event_id
 
     def handle_completion_event(self, event: history.HistoryEvent) -> None:
-        pass
+        """Generic completion event handler."""
+        attr_names = self._get_completion_event_attr_names()
+        event_id_field = self._get_event_id_field_name()
+
+        for attr_name in attr_names:
+            if self._should_handle_event_by_event_id(event, attr_name, event_id_field):
+                # Determine the completion state based on the attribute name
+                if "completed" in attr_name:
+                    self.status = DecisionState.COMPLETED
+                elif "failed" in attr_name:
+                    self.status = DecisionState.FAILED
+                elif "timed_out" in attr_name:
+                    self.status = DecisionState.TIMED_OUT
+                elif "fired" in attr_name:
+                    # Special case for timer fired events
+                    self.status = DecisionState.COMPLETED
+                break
 
     def handle_initiation_failed_event(self, event: history.HistoryEvent) -> None:
+        """Generic initiation failed event handler."""
+        # Default implementation - subclasses can override
         pass
 
     def handle_cancel_initiated_event(self, event: history.HistoryEvent) -> None:
-        pass
+        """Generic cancel initiated event handler."""
+        attr_name = self._get_cancel_initiated_event_attr_name()
+        id_field = self._get_id_field_name()
+
+        if self._should_handle_event(event, attr_name, id_field):
+            if hasattr(self, "_cancel_requested"):
+                self._cancel_requested = True
 
     def handle_cancel_failed_event(self, event: history.HistoryEvent) -> None:
-        pass
+        """Generic cancel failed event handler."""
+        attr_name = self._get_cancel_failed_event_attr_name()
+        id_field = self._get_id_field_name()
+
+        if self._should_handle_event(event, attr_name, id_field):
+            if hasattr(self, "_cancel_emitted"):
+                self._cancel_emitted = False
 
     def handle_canceled_event(self, event: history.HistoryEvent) -> None:
-        pass
+        """Generic canceled event handler."""
+        attr_names = self._get_canceled_event_attr_names()
+        event_id_field = self._get_event_id_field_name()
+
+        for attr_name in attr_names:
+            if self._should_handle_event_by_event_id(event, attr_name, event_id_field):
+                self.status = DecisionState.CANCELED
+                break
 
     def collect_pending_decisions(self) -> List[decision.Decision]:
         """Return any decisions that should be emitted now.
@@ -150,12 +241,12 @@ class DecisionStateMachine:
 
 
 @dataclass
-class ActivityDecisionMachine(DecisionStateMachine):
+class ActivityDecisionMachine(BaseDecisionStateMachine):
     """Tracks lifecycle of a single activity execution by activity_id."""
 
     activity_id: str
     schedule_attributes: decision.ScheduleActivityTaskDecisionAttributes
-    status: MachineStatus = MachineStatus.CREATED
+    status: DecisionState = DecisionState.CREATED
     scheduled_event_id: Optional[int] = None
     started_event_id: Optional[int] = None
     _schedule_emitted: bool = False
@@ -165,52 +256,39 @@ class ActivityDecisionMachine(DecisionStateMachine):
     def get_id(self) -> str:
         return self.activity_id
 
-    def handle_initiated_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "activity_task_scheduled_event_attributes", None)
-        if a is not None and a.activity_id == self.activity_id:
-            self.status = MachineStatus.SCHEDULED
-            self.scheduled_event_id = event.event_id
+    # Implement abstract methods for generic handlers
+    def _get_initiated_event_attr_name(self) -> str:
+        return "activity_task_scheduled_event_attributes"
 
-    def handle_started_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "activity_task_started_event_attributes", None)
-        if a is not None and self.scheduled_event_id and a.scheduled_event_id == self.scheduled_event_id:
-            self.status = MachineStatus.STARTED
-            self.started_event_id = event.event_id
+    def _get_started_event_attr_name(self) -> str:
+        return "activity_task_started_event_attributes"
 
-    def handle_completion_event(self, event: history.HistoryEvent) -> None:
-        if getattr(event, "activity_task_completed_event_attributes", None) is not None:
-            a = event.activity_task_completed_event_attributes
-            if self.scheduled_event_id and a.scheduled_event_id == self.scheduled_event_id:
-                self.status = MachineStatus.COMPLETED
-        elif getattr(event, "activity_task_failed_event_attributes", None) is not None:
-            a = event.activity_task_failed_event_attributes
-            if self.scheduled_event_id and a.scheduled_event_id == self.scheduled_event_id:
-                self.status = MachineStatus.FAILED
-        elif getattr(event, "activity_task_timed_out_event_attributes", None) is not None:
-            a = event.activity_task_timed_out_event_attributes
-            if self.scheduled_event_id and a.scheduled_event_id == self.scheduled_event_id:
-                self.status = MachineStatus.TIMED_OUT
+    def _get_completion_event_attr_names(self) -> List[str]:
+        return [
+            "activity_task_completed_event_attributes",
+            "activity_task_failed_event_attributes",
+            "activity_task_timed_out_event_attributes",
+        ]
 
-    def handle_cancel_initiated_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "activity_task_cancel_requested_event_attributes", None)
-        if a is not None and a.activity_id == self.activity_id:
-            self._cancel_requested = True
+    def _get_cancel_initiated_event_attr_name(self) -> str:
+        return "activity_task_cancel_requested_event_attributes"
 
-    def handle_cancel_failed_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "request_cancel_activity_task_failed_event_attributes", None)
-        if a is not None and a.activity_id == self.activity_id:
-            # allow future cancel retry
-            self._cancel_emitted = False
+    def _get_cancel_failed_event_attr_name(self) -> str:
+        return "request_cancel_activity_task_failed_event_attributes"
 
-    def handle_canceled_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "activity_task_canceled_event_attributes", None)
-        if a is not None and self.scheduled_event_id and a.scheduled_event_id == self.scheduled_event_id:
-            self.status = MachineStatus.CANCELED
+    def _get_canceled_event_attr_names(self) -> List[str]:
+        return ["activity_task_canceled_event_attributes"]
+
+    def _get_id_field_name(self) -> str:
+        return "activity_id"
+
+    def _get_event_id_field_name(self) -> str:
+        return "scheduled_event_id"
 
     def collect_pending_decisions(self) -> List[decision.Decision]:
         decisions: List[decision.Decision] = []
 
-        if self.status is MachineStatus.CREATED and not self._schedule_emitted:
+        if self.status is DecisionState.CREATED and not self._schedule_emitted:
             # Emit initial schedule decision
             decisions.append(
                 decision.Decision(
@@ -219,12 +297,15 @@ class ActivityDecisionMachine(DecisionStateMachine):
             )
             self._schedule_emitted = True
 
-        if self._cancel_requested and not self._cancel_emitted and not self.is_terminal():
+        if (
+            self._cancel_requested
+            and not self._cancel_emitted
+            and not self.is_terminal()
+        ):
             # Emit cancel request
             decisions.append(
                 decision.Decision(
-                    request_cancel_activity_task_decision_attributes=
-                    decision.RequestCancelActivityTaskDecisionAttributes(
+                    request_cancel_activity_task_decision_attributes=decision.RequestCancelActivityTaskDecisionAttributes(
                         activity_id=self.activity_id
                     )
                 )
@@ -239,10 +320,10 @@ class ActivityDecisionMachine(DecisionStateMachine):
 
     def is_terminal(self) -> bool:
         return self.status in (
-            MachineStatus.COMPLETED,
-            MachineStatus.FAILED,
-            MachineStatus.CANCELED,
-            MachineStatus.TIMED_OUT,
+            DecisionState.COMPLETED,
+            DecisionState.FAILED,
+            DecisionState.CANCELED,
+            DecisionState.TIMED_OUT,
         )
 
 
@@ -250,12 +331,12 @@ class ActivityDecisionMachine(DecisionStateMachine):
 
 
 @dataclass
-class TimerDecisionMachine(DecisionStateMachine):
+class TimerDecisionMachine(BaseDecisionStateMachine):
     """Tracks lifecycle of a single workflow timer by timer_id."""
 
     timer_id: str
     start_attributes: decision.StartTimerDecisionAttributes
-    status: MachineStatus = MachineStatus.CREATED
+    status: DecisionState = DecisionState.CREATED
     started_event_id: Optional[int] = None
     _start_emitted: bool = False
     _cancel_requested: bool = False
@@ -264,43 +345,55 @@ class TimerDecisionMachine(DecisionStateMachine):
     def get_id(self) -> str:
         return self.timer_id
 
-    def handle_initiated_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "timer_started_event_attributes", None)
-        if a is not None and a.timer_id == self.timer_id:
-            self.status = MachineStatus.SCHEDULED
-            self.started_event_id = event.event_id
+    # Implement abstract methods for generic handlers
+    def _get_initiated_event_attr_name(self) -> str:
+        return "timer_started_event_attributes"
 
+    def _get_started_event_attr_name(self) -> str:
+        return ""  # Timers don't have a separate started event
+
+    def _get_completion_event_attr_names(self) -> List[str]:
+        return ["timer_fired_event_attributes"]
+
+    def _get_cancel_initiated_event_attr_name(self) -> str:
+        return ""  # Timers don't have cancel initiated events
+
+    def _get_cancel_failed_event_attr_name(self) -> str:
+        return "cancel_timer_failed_event_attributes"
+
+    def _get_canceled_event_attr_names(self) -> List[str]:
+        return ["timer_canceled_event_attributes"]
+
+    def _get_id_field_name(self) -> str:
+        return "timer_id"
+
+    def _get_event_id_field_name(self) -> str:
+        return "started_event_id"
+
+    # Override started event handler since timers don't have separate started events
     def handle_started_event(self, event: history.HistoryEvent) -> None:
         # Timers don't have a separate started beyond TimerStarted
         pass
 
-    def handle_completion_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "timer_fired_event_attributes", None)
-        if a is not None and self.started_event_id and a.started_event_id == self.started_event_id:
-            self.status = MachineStatus.COMPLETED
-
-    def handle_canceled_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "timer_canceled_event_attributes", None)
-        if a is not None and self.started_event_id and a.started_event_id == self.started_event_id:
-            self.status = MachineStatus.CANCELED
-
-    def handle_cancel_failed_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "cancel_timer_failed_event_attributes", None)
-        if a is not None and a.timer_id == self.timer_id:
-            self._cancel_emitted = False
+    # Override cancel initiated handler since timers don't have this event
+    def handle_cancel_initiated_event(self, event: history.HistoryEvent) -> None:
+        # Timers don't have cancel initiated events
+        pass
 
     def collect_pending_decisions(self) -> List[decision.Decision]:
         decisions: List[decision.Decision] = []
 
-        if self.status is MachineStatus.CREATED and not self._start_emitted:
+        if self.status is DecisionState.CREATED and not self._start_emitted:
             decisions.append(
-                decision.Decision(
-                    start_timer_decision_attributes=self.start_attributes
-                )
+                decision.Decision(start_timer_decision_attributes=self.start_attributes)
             )
             self._start_emitted = True
 
-        if self._cancel_requested and not self._cancel_emitted and not self.is_terminal():
+        if (
+            self._cancel_requested
+            and not self._cancel_emitted
+            and not self.is_terminal()
+        ):
             decisions.append(
                 decision.Decision(
                     cancel_timer_decision_attributes=decision.CancelTimerDecisionAttributes(
@@ -318,10 +411,10 @@ class TimerDecisionMachine(DecisionStateMachine):
 
     def is_terminal(self) -> bool:
         return self.status in (
-            MachineStatus.COMPLETED,
-            MachineStatus.CANCELED,
-            MachineStatus.FAILED,
-            MachineStatus.TIMED_OUT,
+            DecisionState.COMPLETED,
+            DecisionState.CANCELED,
+            DecisionState.FAILED,
+            DecisionState.TIMED_OUT,
         )
 
 
@@ -329,7 +422,7 @@ class TimerDecisionMachine(DecisionStateMachine):
 
 
 @dataclass
-class ChildWorkflowDecisionMachine(DecisionStateMachine):
+class ChildWorkflowDecisionMachine(BaseDecisionStateMachine):
     """Tracks lifecycle of a child workflow start/cancel by client-provided id.
 
     Cadence history references child workflows via initiated event IDs. For simplicity,
@@ -339,7 +432,7 @@ class ChildWorkflowDecisionMachine(DecisionStateMachine):
 
     client_id: str
     start_attributes: decision.StartChildWorkflowExecutionDecisionAttributes
-    status: MachineStatus = MachineStatus.CREATED
+    status: DecisionState = DecisionState.CREATED
     initiated_event_id: Optional[int] = None
     started_event_id: Optional[int] = None
     _start_emitted: bool = False
@@ -349,54 +442,81 @@ class ChildWorkflowDecisionMachine(DecisionStateMachine):
     def get_id(self) -> str:
         return self.client_id
 
-    def handle_initiated_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "start_child_workflow_execution_initiated_event_attributes", None)
-        if a is not None and a.workflow_id == self.start_attributes.workflow_id:
-            self.status = MachineStatus.SCHEDULED
-            self.initiated_event_id = event.event_id
+    # Implement abstract methods for generic handlers
+    def _get_initiated_event_attr_name(self) -> str:
+        return "start_child_workflow_execution_initiated_event_attributes"
 
-    def handle_started_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "child_workflow_execution_started_event_attributes", None)
-        if a is not None and self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
-            self.status = MachineStatus.STARTED
-            self.started_event_id = event.event_id
+    def _get_started_event_attr_name(self) -> str:
+        return "child_workflow_execution_started_event_attributes"
 
-    def handle_completion_event(self, event: history.HistoryEvent) -> None:
-        if getattr(event, "child_workflow_execution_completed_event_attributes", None) is not None:
-            a = event.child_workflow_execution_completed_event_attributes
-            if self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
-                self.status = MachineStatus.COMPLETED
-        elif getattr(event, "child_workflow_execution_failed_event_attributes", None) is not None:
-            a = event.child_workflow_execution_failed_event_attributes
-            if self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
-                self.status = MachineStatus.FAILED
-        elif getattr(event, "child_workflow_execution_timed_out_event_attributes", None) is not None:
-            a = event.child_workflow_execution_timed_out_event_attributes
-            if self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
-                self.status = MachineStatus.TIMED_OUT
+    def _get_completion_event_attr_names(self) -> List[str]:
+        return [
+            "child_workflow_execution_completed_event_attributes",
+            "child_workflow_execution_failed_event_attributes",
+            "child_workflow_execution_timed_out_event_attributes",
+        ]
 
-    def handle_canceled_event(self, event: history.HistoryEvent) -> None:
-        if getattr(event, "child_workflow_execution_canceled_event_attributes", None) is not None:
-            a = event.child_workflow_execution_canceled_event_attributes
-            if self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
-                self.status = MachineStatus.CANCELED
-        elif getattr(event, "child_workflow_execution_terminated_event_attributes", None) is not None:
-            a = event.child_workflow_execution_terminated_event_attributes
-            if self.initiated_event_id and a.initiated_event_id == self.initiated_event_id:
-                self.status = MachineStatus.CANCELED
+    def _get_cancel_initiated_event_attr_name(self) -> str:
+        return ""  # Child workflows don't have cancel initiated events
 
+    def _get_cancel_failed_event_attr_name(self) -> str:
+        return ""  # Child workflows don't have cancel failed events
+
+    def _get_canceled_event_attr_names(self) -> List[str]:
+        return [
+            "child_workflow_execution_canceled_event_attributes",
+            "child_workflow_execution_terminated_event_attributes",
+        ]
+
+    def _get_id_field_name(self) -> str:
+        return "workflow_id"
+
+    def _get_event_id_field_name(self) -> str:
+        return "initiated_event_id"
+
+    # Override the generic ID check for child workflows since we need to check workflow_id
+    def _should_handle_event(
+        self, event: history.HistoryEvent, attr_name: str, id_field: str
+    ) -> bool:
+        """Override for child workflows to check workflow_id instead of client_id."""
+        attr = getattr(event, attr_name, None)
+        if attr is None:
+            return False
+
+        # For child workflows, check if the workflow_id matches
+        event_workflow_id = getattr(attr, id_field, None)
+        machine_workflow_id = self.start_attributes.workflow_id
+        return event_workflow_id == machine_workflow_id
+
+    # Override cancel initiated handler since child workflows don't have this event
+    def handle_cancel_initiated_event(self, event: history.HistoryEvent) -> None:
+        # Child workflows don't have cancel initiated events
+        pass
+
+    # Override cancel failed handler since child workflows don't have this event
+    def handle_cancel_failed_event(self, event: history.HistoryEvent) -> None:
+        # Child workflows don't have cancel failed events
+        pass
+
+    # Override initiation failed handler for child workflows
     def handle_initiation_failed_event(self, event: history.HistoryEvent) -> None:
-        a = getattr(event, "start_child_workflow_execution_failed_event_attributes", None)
+        a = getattr(
+            event, "start_child_workflow_execution_failed_event_attributes", None
+        )
         if a is not None and (
-            (hasattr(a, "initiated_event_id") and self.initiated_event_id and a.initiated_event_id == self.initiated_event_id)
+            (
+                hasattr(a, "initiated_event_id")
+                and self.initiated_event_id
+                and a.initiated_event_id == self.initiated_event_id
+            )
             or a.workflow_id == self.start_attributes.workflow_id
         ):
-            self.status = MachineStatus.FAILED
+            self.status = DecisionState.FAILED
 
     def collect_pending_decisions(self) -> List[decision.Decision]:
         decisions: List[decision.Decision] = []
 
-        if self.status is MachineStatus.CREATED and not self._start_emitted:
+        if self.status is DecisionState.CREATED and not self._start_emitted:
             decisions.append(
                 decision.Decision(
                     start_child_workflow_execution_decision_attributes=self.start_attributes
@@ -404,12 +524,15 @@ class ChildWorkflowDecisionMachine(DecisionStateMachine):
             )
             self._start_emitted = True
 
-        if self._cancel_requested and not self._cancel_emitted and not self.is_terminal():
+        if (
+            self._cancel_requested
+            and not self._cancel_emitted
+            and not self.is_terminal()
+        ):
             # Request cancel of the child workflow via external cancel with child_workflow_only
             decisions.append(
                 decision.Decision(
-                    request_cancel_external_workflow_execution_decision_attributes=
-                    decision.RequestCancelExternalWorkflowExecutionDecisionAttributes(
+                    request_cancel_external_workflow_execution_decision_attributes=decision.RequestCancelExternalWorkflowExecutionDecisionAttributes(
                         domain=self.start_attributes.domain,
                         workflow_execution=common.WorkflowExecution(
                             workflow_id=self.start_attributes.workflow_id
@@ -427,10 +550,10 @@ class ChildWorkflowDecisionMachine(DecisionStateMachine):
 
     def is_terminal(self) -> bool:
         return self.status in (
-            MachineStatus.COMPLETED,
-            MachineStatus.FAILED,
-            MachineStatus.CANCELED,
-            MachineStatus.TIMED_OUT,
+            DecisionState.COMPLETED,
+            DecisionState.FAILED,
+            DecisionState.CANCELED,
+            DecisionState.TIMED_OUT,
         )
 
 
@@ -455,7 +578,9 @@ class DecisionManager:
     ) -> ActivityDecisionMachine:
         machine = self.activities.get(activity_id)
         if machine is None or machine.is_terminal():
-            machine = ActivityDecisionMachine(activity_id=activity_id, schedule_attributes=attrs)
+            machine = ActivityDecisionMachine(
+                activity_id=activity_id, schedule_attributes=attrs
+            )
             self.activities[activity_id] = machine
         return machine
 
@@ -483,11 +608,15 @@ class DecisionManager:
     # ----- Child Workflow API -----
 
     def start_child_workflow(
-        self, client_id: str, attrs: decision.StartChildWorkflowExecutionDecisionAttributes
+        self,
+        client_id: str,
+        attrs: decision.StartChildWorkflowExecutionDecisionAttributes,
     ) -> ChildWorkflowDecisionMachine:
         machine = self.children.get(client_id)
         if machine is None or machine.is_terminal():
-            machine = ChildWorkflowDecisionMachine(client_id=client_id, start_attributes=attrs)
+            machine = ChildWorkflowDecisionMachine(
+                client_id=client_id, start_attributes=attrs
+            )
             self.children[client_id] = machine
         return machine
 
@@ -599,5 +728,3 @@ class DecisionManager:
             decisions.extend(machine.collect_pending_decisions())
 
         return decisions
-
-

--- a/tests/cadence/_internal/test_decision_state_machine.py
+++ b/tests/cadence/_internal/test_decision_state_machine.py
@@ -11,7 +11,7 @@ from cadence._internal.decision_state_machine import (
     TimerDecisionMachine,
     ChildWorkflowDecisionMachine,
     DecisionManager,
-    MachineStatus,
+    DecisionState,
 )
 
 
@@ -34,7 +34,9 @@ def test_timer_state_machine_cancel_after_initiated():
     m.handle_initiated_event(
         history.HistoryEvent(
             event_id=1,
-            timer_started_event_attributes=history.TimerStartedEventAttributes(timer_id="t-cai"),
+            timer_started_event_attributes=history.TimerStartedEventAttributes(
+                timer_id="t-cai"
+            ),
         )
     )
     m.request_cancel()
@@ -50,7 +52,9 @@ def test_timer_state_machine_completed_after_cancel():
     m.handle_initiated_event(
         history.HistoryEvent(
             event_id=2,
-            timer_started_event_attributes=history.TimerStartedEventAttributes(timer_id="t-cac"),
+            timer_started_event_attributes=history.TimerStartedEventAttributes(
+                timer_id="t-cac"
+            ),
         )
     )
     m.request_cancel()
@@ -58,10 +62,12 @@ def test_timer_state_machine_completed_after_cancel():
     m.handle_completion_event(
         history.HistoryEvent(
             event_id=3,
-            timer_fired_event_attributes=history.TimerFiredEventAttributes(timer_id="t-cac", started_event_id=2),
+            timer_fired_event_attributes=history.TimerFiredEventAttributes(
+                timer_id="t-cac", started_event_id=2
+            ),
         )
     )
-    assert m.status is MachineStatus.COMPLETED
+    assert m.status is DecisionState.COMPLETED
 
 
 @pytest.mark.unit
@@ -72,20 +78,26 @@ def test_timer_state_machine_complete_without_cancel():
     m.handle_initiated_event(
         history.HistoryEvent(
             event_id=4,
-            timer_started_event_attributes=history.TimerStartedEventAttributes(timer_id="t-cwc"),
+            timer_started_event_attributes=history.TimerStartedEventAttributes(
+                timer_id="t-cwc"
+            ),
         )
     )
     m.handle_completion_event(
         history.HistoryEvent(
             event_id=5,
-            timer_fired_event_attributes=history.TimerFiredEventAttributes(timer_id="t-cwc", started_event_id=4),
+            timer_fired_event_attributes=history.TimerFiredEventAttributes(
+                timer_id="t-cwc", started_event_id=4
+            ),
         )
     )
-    assert m.status is MachineStatus.COMPLETED
+    assert m.status is DecisionState.COMPLETED
 
 
 @pytest.mark.unit
-@pytest.mark.skip("Invalid state transition panics are not applicable in this Python implementation")
+@pytest.mark.skip(
+    "Invalid state transition panics are not applicable in this Python implementation"
+)
 def test_timer_state_machine_panic_invalid_state_transition():
     pass
 
@@ -98,7 +110,9 @@ def test_timer_cancel_event_ordering():
     m.handle_initiated_event(
         history.HistoryEvent(
             event_id=10,
-            timer_started_event_attributes=history.TimerStartedEventAttributes(timer_id="t-ord"),
+            timer_started_event_attributes=history.TimerStartedEventAttributes(
+                timer_id="t-ord"
+            ),
         )
     )
     m.request_cancel()
@@ -108,7 +122,9 @@ def test_timer_cancel_event_ordering():
     m.handle_cancel_failed_event(
         history.HistoryEvent(
             event_id=11,
-            cancel_timer_failed_event_attributes=history.CancelTimerFailedEventAttributes(timer_id="t-ord"),
+            cancel_timer_failed_event_attributes=history.CancelTimerFailedEventAttributes(
+                timer_id="t-ord"
+            ),
         )
     )
     d2 = m.collect_pending_decisions()
@@ -124,13 +140,17 @@ def test_activity_state_machine_complete_without_cancel():
     m.handle_initiated_event(
         history.HistoryEvent(
             event_id=20,
-            activity_task_scheduled_event_attributes=history.ActivityTaskScheduledEventAttributes(activity_id="act-1"),
+            activity_task_scheduled_event_attributes=history.ActivityTaskScheduledEventAttributes(
+                activity_id="act-1"
+            ),
         )
     )
     m.handle_started_event(
         history.HistoryEvent(
             event_id=21,
-            activity_task_started_event_attributes=history.ActivityTaskStartedEventAttributes(scheduled_event_id=20),
+            activity_task_started_event_attributes=history.ActivityTaskStartedEventAttributes(
+                scheduled_event_id=20
+            ),
         )
     )
     m.handle_completion_event(
@@ -141,7 +161,7 @@ def test_activity_state_machine_complete_without_cancel():
             ),
         )
     )
-    assert m.status is MachineStatus.COMPLETED
+    assert m.status is DecisionState.COMPLETED
 
 
 @pytest.mark.unit
@@ -163,7 +183,9 @@ def test_activity_state_machine_cancel_after_sent():
     _ = m.collect_pending_decisions()
     m.request_cancel()
     d = m.collect_pending_decisions()
-    assert len(d) == 1 and d[0].HasField("request_cancel_activity_task_decision_attributes")
+    assert len(d) == 1 and d[0].HasField(
+        "request_cancel_activity_task_decision_attributes"
+    )
 
 
 @pytest.mark.unit
@@ -174,13 +196,17 @@ def test_activity_state_machine_completed_after_cancel():
     m.handle_initiated_event(
         history.HistoryEvent(
             event_id=30,
-            activity_task_scheduled_event_attributes=history.ActivityTaskScheduledEventAttributes(activity_id="act-cac"),
+            activity_task_scheduled_event_attributes=history.ActivityTaskScheduledEventAttributes(
+                activity_id="act-cac"
+            ),
         )
     )
     m.handle_started_event(
         history.HistoryEvent(
             event_id=31,
-            activity_task_started_event_attributes=history.ActivityTaskStartedEventAttributes(scheduled_event_id=30),
+            activity_task_started_event_attributes=history.ActivityTaskStartedEventAttributes(
+                scheduled_event_id=30
+            ),
         )
     )
     m.request_cancel()
@@ -193,11 +219,13 @@ def test_activity_state_machine_completed_after_cancel():
             ),
         )
     )
-    assert m.status is MachineStatus.COMPLETED
+    assert m.status is DecisionState.COMPLETED
 
 
 @pytest.mark.unit
-@pytest.mark.skip("Invalid state transition panics are not applicable in this Python implementation")
+@pytest.mark.skip(
+    "Invalid state transition panics are not applicable in this Python implementation"
+)
 def test_activity_state_machine_panic_invalid_state_transition():
     pass
 
@@ -209,7 +237,9 @@ def test_child_workflow_state_machine_basic():
     )
     m = ChildWorkflowDecisionMachine(client_id="cw-1", start_attributes=attrs)
     d = m.collect_pending_decisions()
-    assert len(d) == 1 and d[0].HasField("start_child_workflow_execution_decision_attributes")
+    assert len(d) == 1 and d[0].HasField(
+        "start_child_workflow_execution_decision_attributes"
+    )
     m.handle_initiated_event(
         history.HistoryEvent(
             event_id=40,
@@ -234,7 +264,7 @@ def test_child_workflow_state_machine_basic():
             ),
         )
     )
-    assert m.status is MachineStatus.COMPLETED
+    assert m.status is DecisionState.COMPLETED
 
 
 @pytest.mark.unit
@@ -254,7 +284,9 @@ def test_child_workflow_state_machine_cancel_succeed():
     )
     m.request_cancel()
     d = m.collect_pending_decisions()
-    assert len(d) == 1 and d[0].HasField("request_cancel_external_workflow_execution_decision_attributes")
+    assert len(d) == 1 and d[0].HasField(
+        "request_cancel_external_workflow_execution_decision_attributes"
+    )
     m.handle_canceled_event(
         history.HistoryEvent(
             event_id=51,
@@ -263,7 +295,7 @@ def test_child_workflow_state_machine_cancel_succeed():
             ),
         )
     )
-    assert m.status is MachineStatus.CANCELED
+    assert m.status is DecisionState.CANCELED
 
 
 @pytest.mark.unit
@@ -285,19 +317,25 @@ def test_marker_state_machine():
 
 
 @pytest.mark.unit
-@pytest.mark.skip("Upsert search attributes decision state machine is not implemented in this module")
+@pytest.mark.skip(
+    "Upsert search attributes decision state machine is not implemented in this module"
+)
 def test_upsert_search_attributes_decision_state_machine():
     pass
 
 
 @pytest.mark.unit
-@pytest.mark.skip("Cancel external workflow decision state machine is not implemented in this module")
+@pytest.mark.skip(
+    "Cancel external workflow decision state machine is not implemented in this module"
+)
 def test_cancel_external_workflow_state_machine_succeed():
     pass
 
 
 @pytest.mark.unit
-@pytest.mark.skip("Cancel external workflow decision state machine is not implemented in this module")
+@pytest.mark.skip(
+    "Cancel external workflow decision state machine is not implemented in this module"
+)
 def test_cancel_external_workflow_state_machine_failed():
     pass
 
@@ -307,7 +345,9 @@ def test_manager_aggregates_and_routes():
     dm = DecisionManager()
 
     # Create three machines via public API
-    a = dm.schedule_activity("a1", decision.ScheduleActivityTaskDecisionAttributes(activity_id="a1"))
+    a = dm.schedule_activity(
+        "a1", decision.ScheduleActivityTaskDecisionAttributes(activity_id="a1")
+    )
     t = dm.start_timer("t1", decision.StartTimerDecisionAttributes(timer_id="t1"))
     c = dm.start_child_workflow(
         "c1",
@@ -327,13 +367,17 @@ def test_manager_aggregates_and_routes():
     dm.handle_history_event(
         history.HistoryEvent(
             event_id=100,
-            activity_task_scheduled_event_attributes=history.ActivityTaskScheduledEventAttributes(activity_id="a1"),
+            activity_task_scheduled_event_attributes=history.ActivityTaskScheduledEventAttributes(
+                activity_id="a1"
+            ),
         )
     )
     dm.handle_history_event(
         history.HistoryEvent(
             event_id=101,
-            timer_started_event_attributes=history.TimerStartedEventAttributes(timer_id="t1"),
+            timer_started_event_attributes=history.TimerStartedEventAttributes(
+                timer_id="t1"
+            ),
         )
     )
     dm.handle_history_event(
@@ -345,15 +389,17 @@ def test_manager_aggregates_and_routes():
         )
     )
 
-    assert a.status is MachineStatus.SCHEDULED
-    assert t.status is MachineStatus.SCHEDULED
-    assert c.status is MachineStatus.SCHEDULED
+    assert a.status is DecisionState.INITIATED
+    assert t.status is DecisionState.INITIATED
+    assert c.status is DecisionState.INITIATED
 
     # Route started and completion events
     dm.handle_history_event(
         history.HistoryEvent(
             event_id=103,
-            activity_task_started_event_attributes=history.ActivityTaskStartedEventAttributes(scheduled_event_id=100),
+            activity_task_started_event_attributes=history.ActivityTaskStartedEventAttributes(
+                scheduled_event_id=100
+            ),
         )
     )
     dm.handle_history_event(
@@ -375,7 +421,9 @@ def test_manager_aggregates_and_routes():
     dm.handle_history_event(
         history.HistoryEvent(
             event_id=106,
-            timer_fired_event_attributes=history.TimerFiredEventAttributes(timer_id="t1", started_event_id=101),
+            timer_fired_event_attributes=history.TimerFiredEventAttributes(
+                timer_id="t1", started_event_id=101
+            ),
         )
     )
     dm.handle_history_event(
@@ -387,8 +435,6 @@ def test_manager_aggregates_and_routes():
         )
     )
 
-    assert a.status is MachineStatus.COMPLETED
-    assert t.status is MachineStatus.COMPLETED
-    assert c.status is MachineStatus.COMPLETED
-
-
+    assert a.status is DecisionState.COMPLETED
+    assert t.status is DecisionState.COMPLETED
+    assert c.status is DecisionState.COMPLETED

--- a/tests/cadence/_internal/test_decision_state_machine.py
+++ b/tests/cadence/_internal/test_decision_state_machine.py
@@ -1,0 +1,394 @@
+import pytest
+
+from cadence.api.v1 import (
+    decision_pb2 as decision,
+    history_pb2 as history,
+    common_pb2 as common,
+)
+
+from cadence._internal.decision_state_machine import (
+    ActivityDecisionMachine,
+    TimerDecisionMachine,
+    ChildWorkflowDecisionMachine,
+    DecisionManager,
+    MachineStatus,
+)
+
+
+@pytest.mark.unit
+def test_timer_state_machine_cancel_before_sent():
+    attrs = decision.StartTimerDecisionAttributes(timer_id="t-cbs")
+    m = TimerDecisionMachine(timer_id="t-cbs", start_attributes=attrs)
+    m.request_cancel()
+    d = m.collect_pending_decisions()
+    assert len(d) == 2
+    assert d[0].HasField("start_timer_decision_attributes")
+    assert d[1].HasField("cancel_timer_decision_attributes")
+
+
+@pytest.mark.unit
+def test_timer_state_machine_cancel_after_initiated():
+    attrs = decision.StartTimerDecisionAttributes(timer_id="t-cai")
+    m = TimerDecisionMachine(timer_id="t-cai", start_attributes=attrs)
+    _ = m.collect_pending_decisions()
+    m.handle_initiated_event(
+        history.HistoryEvent(
+            event_id=1,
+            timer_started_event_attributes=history.TimerStartedEventAttributes(timer_id="t-cai"),
+        )
+    )
+    m.request_cancel()
+    d = m.collect_pending_decisions()
+    assert len(d) == 1 and d[0].HasField("cancel_timer_decision_attributes")
+
+
+@pytest.mark.unit
+def test_timer_state_machine_completed_after_cancel():
+    attrs = decision.StartTimerDecisionAttributes(timer_id="t-cac")
+    m = TimerDecisionMachine(timer_id="t-cac", start_attributes=attrs)
+    _ = m.collect_pending_decisions()
+    m.handle_initiated_event(
+        history.HistoryEvent(
+            event_id=2,
+            timer_started_event_attributes=history.TimerStartedEventAttributes(timer_id="t-cac"),
+        )
+    )
+    m.request_cancel()
+    _ = m.collect_pending_decisions()
+    m.handle_completion_event(
+        history.HistoryEvent(
+            event_id=3,
+            timer_fired_event_attributes=history.TimerFiredEventAttributes(timer_id="t-cac", started_event_id=2),
+        )
+    )
+    assert m.status is MachineStatus.COMPLETED
+
+
+@pytest.mark.unit
+def test_timer_state_machine_complete_without_cancel():
+    attrs = decision.StartTimerDecisionAttributes(timer_id="t-cwc")
+    m = TimerDecisionMachine(timer_id="t-cwc", start_attributes=attrs)
+    _ = m.collect_pending_decisions()
+    m.handle_initiated_event(
+        history.HistoryEvent(
+            event_id=4,
+            timer_started_event_attributes=history.TimerStartedEventAttributes(timer_id="t-cwc"),
+        )
+    )
+    m.handle_completion_event(
+        history.HistoryEvent(
+            event_id=5,
+            timer_fired_event_attributes=history.TimerFiredEventAttributes(timer_id="t-cwc", started_event_id=4),
+        )
+    )
+    assert m.status is MachineStatus.COMPLETED
+
+
+@pytest.mark.unit
+@pytest.mark.skip("Invalid state transition panics are not applicable in this Python implementation")
+def test_timer_state_machine_panic_invalid_state_transition():
+    pass
+
+
+@pytest.mark.unit
+def test_timer_cancel_event_ordering():
+    attrs = decision.StartTimerDecisionAttributes(timer_id="t-ord")
+    m = TimerDecisionMachine(timer_id="t-ord", start_attributes=attrs)
+    _ = m.collect_pending_decisions()
+    m.handle_initiated_event(
+        history.HistoryEvent(
+            event_id=10,
+            timer_started_event_attributes=history.TimerStartedEventAttributes(timer_id="t-ord"),
+        )
+    )
+    m.request_cancel()
+    d1 = m.collect_pending_decisions()
+    assert len(d1) == 1 and d1[0].HasField("cancel_timer_decision_attributes")
+    # Simulate cancel failed -> should retry emit
+    m.handle_cancel_failed_event(
+        history.HistoryEvent(
+            event_id=11,
+            cancel_timer_failed_event_attributes=history.CancelTimerFailedEventAttributes(timer_id="t-ord"),
+        )
+    )
+    d2 = m.collect_pending_decisions()
+    assert len(d2) == 1 and d2[0].HasField("cancel_timer_decision_attributes")
+
+
+@pytest.mark.unit
+def test_activity_state_machine_complete_without_cancel():
+    attrs = decision.ScheduleActivityTaskDecisionAttributes(activity_id="act-1")
+    m = ActivityDecisionMachine(activity_id="act-1", schedule_attributes=attrs)
+    d = m.collect_pending_decisions()
+    assert len(d) == 1 and d[0].HasField("schedule_activity_task_decision_attributes")
+    m.handle_initiated_event(
+        history.HistoryEvent(
+            event_id=20,
+            activity_task_scheduled_event_attributes=history.ActivityTaskScheduledEventAttributes(activity_id="act-1"),
+        )
+    )
+    m.handle_started_event(
+        history.HistoryEvent(
+            event_id=21,
+            activity_task_started_event_attributes=history.ActivityTaskStartedEventAttributes(scheduled_event_id=20),
+        )
+    )
+    m.handle_completion_event(
+        history.HistoryEvent(
+            event_id=22,
+            activity_task_completed_event_attributes=history.ActivityTaskCompletedEventAttributes(
+                scheduled_event_id=20, started_event_id=21
+            ),
+        )
+    )
+    assert m.status is MachineStatus.COMPLETED
+
+
+@pytest.mark.unit
+def test_activity_state_machine_cancel_before_sent():
+    attrs = decision.ScheduleActivityTaskDecisionAttributes(activity_id="act-cbs")
+    m = ActivityDecisionMachine(activity_id="act-cbs", schedule_attributes=attrs)
+    m.request_cancel()
+    d = m.collect_pending_decisions()
+    # Should emit schedule then cancel
+    assert len(d) == 2
+    assert d[0].HasField("schedule_activity_task_decision_attributes")
+    assert d[1].HasField("request_cancel_activity_task_decision_attributes")
+
+
+@pytest.mark.unit
+def test_activity_state_machine_cancel_after_sent():
+    attrs = decision.ScheduleActivityTaskDecisionAttributes(activity_id="act-cas")
+    m = ActivityDecisionMachine(activity_id="act-cas", schedule_attributes=attrs)
+    _ = m.collect_pending_decisions()
+    m.request_cancel()
+    d = m.collect_pending_decisions()
+    assert len(d) == 1 and d[0].HasField("request_cancel_activity_task_decision_attributes")
+
+
+@pytest.mark.unit
+def test_activity_state_machine_completed_after_cancel():
+    attrs = decision.ScheduleActivityTaskDecisionAttributes(activity_id="act-cac")
+    m = ActivityDecisionMachine(activity_id="act-cac", schedule_attributes=attrs)
+    _ = m.collect_pending_decisions()
+    m.handle_initiated_event(
+        history.HistoryEvent(
+            event_id=30,
+            activity_task_scheduled_event_attributes=history.ActivityTaskScheduledEventAttributes(activity_id="act-cac"),
+        )
+    )
+    m.handle_started_event(
+        history.HistoryEvent(
+            event_id=31,
+            activity_task_started_event_attributes=history.ActivityTaskStartedEventAttributes(scheduled_event_id=30),
+        )
+    )
+    m.request_cancel()
+    _ = m.collect_pending_decisions()
+    m.handle_completion_event(
+        history.HistoryEvent(
+            event_id=32,
+            activity_task_completed_event_attributes=history.ActivityTaskCompletedEventAttributes(
+                scheduled_event_id=30, started_event_id=31
+            ),
+        )
+    )
+    assert m.status is MachineStatus.COMPLETED
+
+
+@pytest.mark.unit
+@pytest.mark.skip("Invalid state transition panics are not applicable in this Python implementation")
+def test_activity_state_machine_panic_invalid_state_transition():
+    pass
+
+
+@pytest.mark.unit
+def test_child_workflow_state_machine_basic():
+    attrs = decision.StartChildWorkflowExecutionDecisionAttributes(
+        domain="d1", workflow_id="wf-1", workflow_type=common.WorkflowType(name="t")
+    )
+    m = ChildWorkflowDecisionMachine(client_id="cw-1", start_attributes=attrs)
+    d = m.collect_pending_decisions()
+    assert len(d) == 1 and d[0].HasField("start_child_workflow_execution_decision_attributes")
+    m.handle_initiated_event(
+        history.HistoryEvent(
+            event_id=40,
+            start_child_workflow_execution_initiated_event_attributes=history.StartChildWorkflowExecutionInitiatedEventAttributes(
+                domain="d1", workflow_id="wf-1"
+            ),
+        )
+    )
+    m.handle_started_event(
+        history.HistoryEvent(
+            event_id=41,
+            child_workflow_execution_started_event_attributes=history.ChildWorkflowExecutionStartedEventAttributes(
+                initiated_event_id=40
+            ),
+        )
+    )
+    m.handle_completion_event(
+        history.HistoryEvent(
+            event_id=42,
+            child_workflow_execution_completed_event_attributes=history.ChildWorkflowExecutionCompletedEventAttributes(
+                initiated_event_id=40
+            ),
+        )
+    )
+    assert m.status is MachineStatus.COMPLETED
+
+
+@pytest.mark.unit
+def test_child_workflow_state_machine_cancel_succeed():
+    attrs = decision.StartChildWorkflowExecutionDecisionAttributes(
+        domain="d2", workflow_id="wf-2", workflow_type=common.WorkflowType(name="t2")
+    )
+    m = ChildWorkflowDecisionMachine(client_id="cw-2", start_attributes=attrs)
+    _ = m.collect_pending_decisions()
+    m.handle_initiated_event(
+        history.HistoryEvent(
+            event_id=50,
+            start_child_workflow_execution_initiated_event_attributes=history.StartChildWorkflowExecutionInitiatedEventAttributes(
+                domain="d2", workflow_id="wf-2"
+            ),
+        )
+    )
+    m.request_cancel()
+    d = m.collect_pending_decisions()
+    assert len(d) == 1 and d[0].HasField("request_cancel_external_workflow_execution_decision_attributes")
+    m.handle_canceled_event(
+        history.HistoryEvent(
+            event_id=51,
+            child_workflow_execution_canceled_event_attributes=history.ChildWorkflowExecutionCanceledEventAttributes(
+                initiated_event_id=50
+            ),
+        )
+    )
+    assert m.status is MachineStatus.CANCELED
+
+
+@pytest.mark.unit
+@pytest.mark.skip("Invalid state checks from Go are not applicable here")
+def test_child_workflow_state_machine_invalid_states():
+    pass
+
+
+@pytest.mark.unit
+@pytest.mark.skip("External cancel failure event handling is not implemented")
+def test_child_workflow_state_machine_cancel_failed():
+    pass
+
+
+@pytest.mark.unit
+@pytest.mark.skip("Marker decision state machine is not implemented in this module")
+def test_marker_state_machine():
+    pass
+
+
+@pytest.mark.unit
+@pytest.mark.skip("Upsert search attributes decision state machine is not implemented in this module")
+def test_upsert_search_attributes_decision_state_machine():
+    pass
+
+
+@pytest.mark.unit
+@pytest.mark.skip("Cancel external workflow decision state machine is not implemented in this module")
+def test_cancel_external_workflow_state_machine_succeed():
+    pass
+
+
+@pytest.mark.unit
+@pytest.mark.skip("Cancel external workflow decision state machine is not implemented in this module")
+def test_cancel_external_workflow_state_machine_failed():
+    pass
+
+
+@pytest.mark.unit
+def test_manager_aggregates_and_routes():
+    dm = DecisionManager()
+
+    # Create three machines via public API
+    a = dm.schedule_activity("a1", decision.ScheduleActivityTaskDecisionAttributes(activity_id="a1"))
+    t = dm.start_timer("t1", decision.StartTimerDecisionAttributes(timer_id="t1"))
+    c = dm.start_child_workflow(
+        "c1",
+        decision.StartChildWorkflowExecutionDecisionAttributes(
+            domain="d", workflow_id="w1", workflow_type=common.WorkflowType(name="t")
+        ),
+    )
+
+    # First collect should include 3 decisions (schedule/start/start_child)
+    decisions_first = dm.collect_pending_decisions()
+    assert len(decisions_first) == 3
+
+    # Idempotent on second collect
+    assert dm.collect_pending_decisions() == []
+
+    # Route initiated events
+    dm.handle_history_event(
+        history.HistoryEvent(
+            event_id=100,
+            activity_task_scheduled_event_attributes=history.ActivityTaskScheduledEventAttributes(activity_id="a1"),
+        )
+    )
+    dm.handle_history_event(
+        history.HistoryEvent(
+            event_id=101,
+            timer_started_event_attributes=history.TimerStartedEventAttributes(timer_id="t1"),
+        )
+    )
+    dm.handle_history_event(
+        history.HistoryEvent(
+            event_id=102,
+            start_child_workflow_execution_initiated_event_attributes=history.StartChildWorkflowExecutionInitiatedEventAttributes(
+                domain="d", workflow_id="w1"
+            ),
+        )
+    )
+
+    assert a.status is MachineStatus.SCHEDULED
+    assert t.status is MachineStatus.SCHEDULED
+    assert c.status is MachineStatus.SCHEDULED
+
+    # Route started and completion events
+    dm.handle_history_event(
+        history.HistoryEvent(
+            event_id=103,
+            activity_task_started_event_attributes=history.ActivityTaskStartedEventAttributes(scheduled_event_id=100),
+        )
+    )
+    dm.handle_history_event(
+        history.HistoryEvent(
+            event_id=104,
+            child_workflow_execution_started_event_attributes=history.ChildWorkflowExecutionStartedEventAttributes(
+                initiated_event_id=102
+            ),
+        )
+    )
+    dm.handle_history_event(
+        history.HistoryEvent(
+            event_id=105,
+            activity_task_completed_event_attributes=history.ActivityTaskCompletedEventAttributes(
+                scheduled_event_id=100, started_event_id=103
+            ),
+        )
+    )
+    dm.handle_history_event(
+        history.HistoryEvent(
+            event_id=106,
+            timer_fired_event_attributes=history.TimerFiredEventAttributes(timer_id="t1", started_event_id=101),
+        )
+    )
+    dm.handle_history_event(
+        history.HistoryEvent(
+            event_id=107,
+            child_workflow_execution_completed_event_attributes=history.ChildWorkflowExecutionCompletedEventAttributes(
+                initiated_event_id=102
+            ),
+        )
+    )
+
+    assert a.status is MachineStatus.COMPLETED
+    assert t.status is MachineStatus.COMPLETED
+    assert c.status is MachineStatus.COMPLETED
+
+


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Implemented decision state machine system for Cadence Python client including:
- Base `DecisionStateMachine` class for workflow decision lifecycle tracking
- `ActivityDecisionMachine` for activity task scheduling, execution, and cancellation
- `TimerDecisionMachine` for timer operations
- `ChildWorkflowDecisionMachine` for child workflow lifecycle management
- `DecisionManager` for aggregating state machines and coordinating decisions

Also try to use proto types directly and avoid any mapping

(heavily relied on Go client state machine: https://github.com/cadence-workflow/cadence-go-client/blob/master/internal/internal_decision_state_machine.go)

<!-- Tell your future self why have you made these changes -->
**Why?**
Workflows need to track what decisions they've made and what state they're in. This state machine ensures decisions are made correctly, in the right order, and handles properly. It's essential for deterministic workflow execution.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local unit tests
```bash
uv test
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**