### PR TITLE
Align DataConverter with Go Client

### DIFF
--- a/cadence/_internal/activity/_activity_executor.py
+++ b/cadence/_internal/activity/_activity_executor.py
@@ -57,7 +57,7 @@ class ActivityExecutor:
             _logger.exception('Exception reporting activity failure')
 
     async def _report_success(self, task: PollForActivityTaskResponse, result: Any):
-        as_payload = await self._data_converter.to_data(result)
+        as_payload = await self._data_converter.to_data([result])
 
         try:
             await self._client.worker_stub.RespondActivityTaskCompleted(RespondActivityTaskCompletedRequest(

--- a/tests/cadence/_internal/activity/test_activity_executor.py
+++ b/tests/cadence/_internal/activity/test_activity_executor.py
@@ -82,7 +82,7 @@ async def test_activity_args(client):
 
     executor = ActivityExecutor(client, 'task_list', 'identity', 1, reg.get_activity)
 
-    await executor.execute(fake_task("activity_type", '["hello", "world"]'))
+    await executor.execute(fake_task("activity_type", '"hello" "world"'))
 
     worker_stub.RespondActivityTaskCompleted.assert_called_once_with(RespondActivityTaskCompletedRequest(
         task_token=b'task_token',


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Make DataConverter match Go rather than Java.

<!-- Tell your future self why have you made these changes -->
**Why?**
- The Go DataConverter's approach is unique and potentially difficult to parse. But it's unambiguous. The Java client either wraps the input into a json array, or encodes it as-is if there's a single value. This ends up being ambiguous as to how it should be decoded any time a List is one of the arguments.
- We could alternatively always wrap the arguments into a list, but introducing a third standard seems worse.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- None
- 
<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**