### PR TITLE
Add WorkflowDefinition

### DIFF
--- a/cadence/worker/_decision_task_handler.py
+++ b/cadence/worker/_decision_task_handler.py
@@ -76,7 +76,7 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
         )
         
         try:
-            workflow_func = self._registry.get_workflow(workflow_type_name)
+            workflow_definition = self._registry.get_workflow(workflow_type_name)
         except KeyError:
             logger.error(
                 "Workflow type not found in registry",
@@ -105,7 +105,7 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
                 workflow_engine = WorkflowEngine(
                     info=workflow_info, 
                     client=self._client, 
-                    workflow_func=workflow_func
+                    workflow_func=workflow_definition.fn
                 )
                 self._workflow_engines[cache_key] = workflow_engine
         

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -2,9 +2,146 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Iterator
+from functools import update_wrapper
+from inspect import signature, Parameter
+from typing import Iterator, Callable, TypeVar, ParamSpec, Generic, TypedDict, Unpack, overload, get_type_hints, Type, Any
 
 from cadence.client import Client
+
+
+@dataclass(frozen=True)
+class WorkflowParameter:
+    """Parameter information for a workflow function."""
+    name: str
+    type_hint: Type | None
+    default_value: Any | None
+
+
+class WorkflowDefinitionOptions(TypedDict, total=False):
+    """Options for defining a workflow."""
+    name: str
+
+
+P = ParamSpec('P')
+T = TypeVar('T')
+
+
+class WorkflowDefinition(Generic[P, T]):
+    """
+    Definition of a workflow function with metadata.
+
+    Similar to ActivityDefinition but for workflows.
+    Provides type safety and metadata for workflow functions.
+    """
+
+    def __init__(self, wrapped: Callable[P, T], name: str, params: list[WorkflowParameter]):
+        self._wrapped = wrapped
+        self._name = name
+        self._params = params
+        update_wrapper(self, wrapped)
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
+        return self._wrapped(*args, **kwargs)
+
+    @property
+    def name(self) -> str:
+        """Get the workflow name."""
+        return self._name
+
+    @property
+    def params(self) -> list[WorkflowParameter]:
+        """Get the workflow parameters."""
+        return self._params
+
+    @property
+    def fn(self) -> Callable[P, T]:
+        """Get the underlying workflow function."""
+        return self._wrapped
+
+    @classmethod
+    def wrap(cls, fn: Callable[P, T], opts: WorkflowDefinitionOptions) -> 'WorkflowDefinition[P, T]':
+        """
+        Wrap a function as a WorkflowDefinition.
+
+        Args:
+            fn: The workflow function to wrap
+            opts: Options for the workflow definition
+
+        Returns:
+            A WorkflowDefinition instance
+        """
+        name = fn.__qualname__
+        if "name" in opts and opts["name"]:
+            name = opts["name"]
+
+        params = _get_workflow_params(fn)
+        return cls(fn, name, params)
+
+
+WorkflowDecorator = Callable[[Callable[P, T]], WorkflowDefinition[P, T]]
+
+
+@overload
+def defn(fn: Callable[P, T]) -> WorkflowDefinition[P, T]:
+    ...
+
+
+@overload
+def defn(**kwargs: Unpack[WorkflowDefinitionOptions]) -> WorkflowDecorator:
+    ...
+
+
+def defn(fn: Callable[P, T] | None = None, **kwargs: Unpack[WorkflowDefinitionOptions]) -> WorkflowDecorator | WorkflowDefinition[P, T]:
+    """
+    Decorator to define a workflow function.
+
+    Usage:
+        @defn
+        def my_workflow(input_data: str) -> str:
+            return f"processed: {input_data}"
+
+        @defn(name="custom_workflow_name")
+        def my_other_workflow(input_data: str) -> str:
+            return f"custom: {input_data}"
+
+    Args:
+        fn: The workflow function (when used without parentheses)
+        **kwargs: Workflow definition options
+
+    Returns:
+        Either a WorkflowDefinition (direct decoration) or a decorator function
+    """
+    opts = WorkflowDefinitionOptions(**kwargs)
+
+    def decorator(inner_fn: Callable[P, T]) -> WorkflowDefinition[P, T]:
+        return WorkflowDefinition.wrap(inner_fn, opts)
+
+    if fn is not None:
+        return decorator(fn)
+
+    return decorator
+
+
+def _get_workflow_params(fn: Callable) -> list[WorkflowParameter]:
+    """Extract parameter information from a workflow function."""
+    args = signature(fn).parameters
+    hints = get_type_hints(fn)
+    result = []
+    for name, param in args.items():
+        # Filter out self parameter
+        if param.name == "self":
+            continue
+        default = None
+        if param.default != Parameter.empty:
+            default = param.default
+        if param.kind in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD):
+            type_hint = hints.get(name, None)
+            result.append(WorkflowParameter(name, type_hint, default))
+        else:
+            raise ValueError(f"Parameters must be positional. {name} is {param.kind}, and not valid")
+
+    return result
+
 
 @dataclass
 class WorkflowInfo:

--- a/tests/cadence/worker/test_decision_task_handler_integration.py
+++ b/tests/cadence/worker/test_decision_task_handler_integration.py
@@ -35,12 +35,12 @@ class TestDecisionTaskHandlerIntegration:
     def registry(self):
         """Create a registry with a test workflow."""
         reg = Registry()
-        
-        @reg.workflow
+
+        @reg.workflow(name="test_workflow")
         def test_workflow(input_data):
             """Simple test workflow that returns the input."""
             return f"processed: {input_data}"
-        
+
         return reg
 
     @pytest.fixture

--- a/tests/cadence/worker/test_registry.py
+++ b/tests/cadence/worker/test_registry.py
@@ -30,16 +30,21 @@ class TestRegistry:
             @reg.workflow
             def test_func():
                 return "test"
-            
-            func = reg.get_workflow("test_func")
+
+            # Registry stores WorkflowDefinition internally
+            func_def = reg.get_workflow(test_func.__name__)
+            # WorkflowDefinition can be called directly
+            assert func_def() == "test"
+            # Verify it's actually a WorkflowDefinition
+            from cadence.workflow import WorkflowDefinition
+            assert isinstance(func_def, WorkflowDefinition)
         else:
             @reg.activity
             def test_func():
                 return "test"
             
             func = reg.get_activity(test_func.name)
-        
-        assert func() == "test"
+            assert func() == "test"
     
     def test_direct_call_behavior(self):
         reg = Registry()

--- a/tests/cadence/worker/test_task_handler_integration.py
+++ b/tests/cadence/worker/test_task_handler_integration.py
@@ -61,11 +61,14 @@ class TestTaskHandlerIntegration:
     @pytest.mark.asyncio
     async def test_full_task_handling_flow_success(self, handler, sample_decision_task, mock_registry):
         """Test the complete task handling flow from base handler through decision handler."""
-        # Mock workflow function
-        def mock_workflow_func(input_data):
-            return f"processed: {input_data}"
-        
-        mock_registry.get_workflow.return_value = mock_workflow_func
+        # Create actual workflow definition
+        def mock_workflow_func():
+            return "test_result"
+
+        from cadence.workflow import WorkflowDefinition, WorkflowDefinitionOptions
+        workflow_opts = WorkflowDefinitionOptions(name="test_workflow")
+        workflow_definition = WorkflowDefinition.wrap(mock_workflow_func, workflow_opts)
+        mock_registry.get_workflow.return_value = workflow_definition
         
         # Mock workflow engine
         mock_engine = Mock(spec=WorkflowEngine)
@@ -86,11 +89,14 @@ class TestTaskHandlerIntegration:
     @pytest.mark.asyncio
     async def test_full_task_handling_flow_with_error(self, handler, sample_decision_task, mock_registry):
         """Test the complete task handling flow when an error occurs."""
-        # Mock workflow function
-        def mock_workflow_func(input_data):
-            return f"processed: {input_data}"
-        
-        mock_registry.get_workflow.return_value = mock_workflow_func
+        # Create actual workflow definition
+        def mock_workflow_func():
+            return "test_result"
+
+        from cadence.workflow import WorkflowDefinition, WorkflowDefinitionOptions
+        workflow_opts = WorkflowDefinitionOptions(name="test_workflow")
+        workflow_definition = WorkflowDefinition.wrap(mock_workflow_func, workflow_opts)
+        mock_registry.get_workflow.return_value = workflow_definition
         
         # Mock workflow engine to raise an error
         mock_engine = Mock(spec=WorkflowEngine)
@@ -110,11 +116,14 @@ class TestTaskHandlerIntegration:
     @pytest.mark.asyncio
     async def test_context_activation_integration(self, handler, sample_decision_task, mock_registry):
         """Test that context activation works correctly in the integration."""
-        # Mock workflow function
-        def mock_workflow_func(input_data):
-            return f"processed: {input_data}"
-        
-        mock_registry.get_workflow.return_value = mock_workflow_func
+        # Create actual workflow definition
+        def mock_workflow_func():
+            return "test_result"
+
+        from cadence.workflow import WorkflowDefinition, WorkflowDefinitionOptions
+        workflow_opts = WorkflowDefinitionOptions(name="test_workflow")
+        workflow_definition = WorkflowDefinition.wrap(mock_workflow_func, workflow_opts)
+        mock_registry.get_workflow.return_value = workflow_definition
         
         # Mock workflow engine
         mock_engine = Mock(spec=WorkflowEngine)
@@ -144,11 +153,14 @@ class TestTaskHandlerIntegration:
     @pytest.mark.asyncio
     async def test_multiple_workflow_executions(self, handler, mock_registry):
         """Test handling multiple workflow executions creates new engines for each."""
-        # Mock workflow function
-        def mock_workflow_func(input_data):
-            return f"processed: {input_data}"
-        
-        mock_registry.get_workflow.return_value = mock_workflow_func
+        # Create actual workflow definition
+        def mock_workflow_func():
+            return "test_result"
+
+        from cadence.workflow import WorkflowDefinition, WorkflowDefinitionOptions
+        workflow_opts = WorkflowDefinitionOptions(name="test_workflow")
+        workflow_definition = WorkflowDefinition.wrap(mock_workflow_func, workflow_opts)
+        mock_registry.get_workflow.return_value = workflow_definition
         
         # Create multiple decision tasks for different workflows
         task1 = Mock(spec=PollForDecisionTaskResponse)
@@ -194,11 +206,14 @@ class TestTaskHandlerIntegration:
     @pytest.mark.asyncio
     async def test_workflow_engine_creation_integration(self, handler, sample_decision_task, mock_registry):
         """Test workflow engine creation integration."""
-        # Mock workflow function
-        def mock_workflow_func(input_data):
-            return f"processed: {input_data}"
-        
-        mock_registry.get_workflow.return_value = mock_workflow_func
+        # Create actual workflow definition
+        def mock_workflow_func():
+            return "test_result"
+
+        from cadence.workflow import WorkflowDefinition, WorkflowDefinitionOptions
+        workflow_opts = WorkflowDefinitionOptions(name="test_workflow")
+        workflow_definition = WorkflowDefinition.wrap(mock_workflow_func, workflow_opts)
+        mock_registry.get_workflow.return_value = workflow_definition
         
         # Mock workflow engine
         mock_engine = Mock(spec=WorkflowEngine)
@@ -218,11 +233,14 @@ class TestTaskHandlerIntegration:
     @pytest.mark.asyncio
     async def test_error_handling_with_context_cleanup(self, handler, sample_decision_task, mock_registry):
         """Test that context cleanup happens even when errors occur."""
-        # Mock workflow function
-        def mock_workflow_func(input_data):
-            return f"processed: {input_data}"
-        
-        mock_registry.get_workflow.return_value = mock_workflow_func
+        # Create actual workflow definition
+        def mock_workflow_func():
+            return "test_result"
+
+        from cadence.workflow import WorkflowDefinition, WorkflowDefinitionOptions
+        workflow_opts = WorkflowDefinitionOptions(name="test_workflow")
+        workflow_definition = WorkflowDefinition.wrap(mock_workflow_func, workflow_opts)
+        mock_registry.get_workflow.return_value = workflow_definition
         
         # Mock workflow engine to raise an error
         mock_engine = Mock(spec=WorkflowEngine)
@@ -255,11 +273,14 @@ class TestTaskHandlerIntegration:
         """Test handling multiple tasks concurrently."""
         import asyncio
         
-        # Mock workflow function
-        def mock_workflow_func(input_data):
-            return f"processed: {input_data}"
-        
-        mock_registry.get_workflow.return_value = mock_workflow_func
+        # Create actual workflow definition
+        def mock_workflow_func():
+            return "test_result"
+
+        from cadence.workflow import WorkflowDefinition, WorkflowDefinitionOptions
+        workflow_opts = WorkflowDefinitionOptions(name="test_workflow")
+        workflow_definition = WorkflowDefinition.wrap(mock_workflow_func, workflow_opts)
+        mock_registry.get_workflow.return_value = workflow_definition
         
         # Create multiple tasks
         tasks = []


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Added `WorkflowDefinition` class with type-safe wrapper for workflow functions, including `.fn`, `.name`, and `.params` properties for metadata access
- Registry now stores `WorkflowDefinition` internally instead of raw callables, with `get_workflow()` returning the typed wrapper
- Introduced `WorkflowParameter` dataclass for parameter introspection (name, type hints, defaults) and `@defn` decorator for standalone workflow definition

<!-- Tell your future self why have you made these changes -->
**Why?**
- Enables compile-time type checking via mypy and better IDE support, consistent with existing `ActivityDefinition` pattern
- Enables parameter validation, automatic API documentation, dynamic workflow discovery, and better error messages

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**