### PR TITLE
feat(version): use dynamic versioning

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -12,11 +12,11 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Set up uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
           uv sync --extra dev
@@ -44,11 +44,11 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Set up uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
           uv sync --extra dev --extra openai
@@ -64,11 +64,11 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Set up uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
           uv sync --extra dev
@@ -84,11 +84,11 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Set up uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
           uv sync --extra dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0", "setuptools-scm[simple]>=9.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "cadence-python-client"
-version = "0.2.0"
+dynamic = ["version"] # version is dynamically determined by setuptools-scm by git tags
 description = "Python framework for authoring Cadence workflows and activities"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -48,6 +48,7 @@ dev = [
     "pytest-docker>=3.2.3",
     "opentelemetry-instrumentation-grpc==0.60b1",
     "opentelemetry-sdk>=1.39.1",
+    "setuptools-scm[simple]>=9.2"
 ]
 docs = [
     "sphinx>=6.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -171,7 +171,6 @@ wheels = [
 
 [[package]]
 name = "cadence-python-client"
-version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },
@@ -196,6 +195,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-docker" },
+    { name = "setuptools-scm" },
 ]
 docs = [
     { name = "myst-parser" },
@@ -235,6 +235,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-docker", marker = "extra == 'dev'", specifier = ">=3.2.3" },
     { name = "requests", marker = "extra == 'examples'", specifier = ">=2.28.0" },
+    { name = "setuptools-scm", extras = ["simple"], marker = "extra == 'dev'", specifier = ">=9.2" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=6.0.0" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=1.2.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
@@ -1873,6 +1874,20 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools-scm"
+version = "10.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "vcs-versioning" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/b1/2a6a8ecd6f9e263754036a0b573360bdbd6873b595725e49e11139722041/setuptools_scm-10.0.5.tar.gz", hash = "sha256:bbba8fe754516cdefd017f4456721775e6ef9662bd7887fb52ae26813d4838c3", size = 56748, upload-time = "2026-03-27T15:57:05.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e1/342c4434df56aa537f6ce7647eefee521d96fbb828b08acd709865767652/setuptools_scm-10.0.5-py3-none-any.whl", hash = "sha256:f611037d8aae618221503b8fa89319f073438252ae3420e01c9ceec249131a0a", size = 21695, upload-time = "2026-03-27T15:57:03.969Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2128,6 +2143,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
+]
+
+[[package]]
+name = "vcs-versioning"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/42/d97a7795055677961c63a1eef8e7b19d5968ed992ed3a70ab8eb012efad8/vcs_versioning-1.1.1.tar.gz", hash = "sha256:fabd75a3cab7dd8ac02fe24a3a9ba936bf258667b5a62ed468c9a1da0f5775bc", size = 97575, upload-time = "2026-03-27T20:42:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/60/73603fbcdbe5e803855bcce4414f94eaeed449083bd8183e67161af78188/vcs_versioning-1.1.1-py3-none-any.whl", hash = "sha256:b541e2ba79fc6aaa3850f8a7f88af43d97c1c80649c01142ee4146eddbc599e4", size = 79851, upload-time = "2026-03-27T20:42:40.45Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* change toml file to be dynamic versioning
* use setuptools-scm for provide source of version
* remove wheel (not needed from new versions)

<!-- Tell your future self why have you made these changes -->
**Why?**

easier to tag a new release without human error.

New process:

Write a release note and tag the commit on github website directly.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

run setuptools_scm locally to check version (I've tag 0.2.1 as local version)
```
shengs@shengs-DQG34F2RHF cadence-python-client % uv run python -m setuptools_scm
toml section missing PosixPath('/Users/shengs/code/me/cadence-python-client/pyproject.toml') does not contain any of the tool sections: ['vcs-versioning', 'setuptools_scm']
0.2.1
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**