### PR TITLE
chore: separate openai contrib from main type-check

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
@@ -86,7 +86,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -51,6 +51,26 @@ jobs:
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
+          uv sync --extra dev
+      - name: Run mypy type checker
+        run: |
+          uv run mypy cadence/
+
+    type-check-contrib:
+    name: Type Safety Check (contrib)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install dependencies
+        run: |
           uv sync --extra dev --extra openai
       - name: Run mypy type checker
         run: |

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           uv run mypy cadence/
 
-    type-check-contrib:
+  type-check-contrib:
     name: Type Safety Check (contrib)
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ exclude = [
     "cadence/api",
     "cadence/api/.*",
     "cadence/sample",
+    # Optional plugins (e.g. OpenAI) use extra deps; omit from default mypy
+    "cadence/contrib",
+    "cadence/contrib/.*",
 ]
 
 # Reduce recursive module checking


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
split core package's ci with plugin ci since min python version is different

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**