### PR TITLE
feat: define retryPolicy, map to proto types, and add to activityOption

### DIFF
--- a/cadence/_internal/workflow/context.py
+++ b/cadence/_internal/workflow/context.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from math import ceil
 from typing import Iterator, Optional, Any, Unpack, Type, cast
 
+from cadence._internal.workflow.retry_policy import retry_policy_to_proto
 from cadence._internal.workflow.statemachine.decision_manager import DecisionManager
 from cadence.api.v1.common_pb2 import ActivityType
 from cadence.api.v1.decision_pb2 import (
@@ -11,14 +12,17 @@ from cadence.api.v1.decision_pb2 import (
 )
 from cadence.api.v1.tasklist_pb2 import TaskList, TaskListKind
 from cadence.data_converter import DataConverter
-from cadence.workflow import WorkflowContext, WorkflowInfo, ResultType, ActivityOptions
-
-default_activity_options = ActivityOptions(
-    schedule_to_close_timeout=timedelta(
-        hours=1
-    ),  # more than 1 hour is recommended to set up options explicitly like heartbeat for self recovery
-    schedule_to_start_timeout=timedelta(seconds=10),
+from cadence.workflow import (
+    ActivityOptions,
+    ResultType,
+    WorkflowContext,
+    WorkflowInfo,
 )
+
+_DEFAULT_ACTIVITY_OPTIONS: ActivityOptions = {
+    "schedule_to_close_timeout": timedelta(hours=1),
+    "schedule_to_start_timeout": timedelta(seconds=10),
+}
 
 
 class Context(WorkflowContext):
@@ -45,7 +49,7 @@ class Context(WorkflowContext):
         *args: Any,
         **kwargs: Unpack[ActivityOptions],
     ) -> ResultType:
-        opts: ActivityOptions = {**default_activity_options, **kwargs}
+        opts: ActivityOptions = {**_DEFAULT_ACTIVITY_OPTIONS, **kwargs}
         if "schedule_to_close_timeout" not in opts and (
             "schedule_to_start_timeout" not in opts
             or "start_to_close_timeout" not in opts
@@ -87,7 +91,7 @@ class Context(WorkflowContext):
             schedule_to_start_timeout=_round_to_nearest_second(schedule_to_start),
             start_to_close_timeout=_round_to_nearest_second(start_to_close),
             heartbeat_timeout=_round_to_nearest_second(heartbeat),
-            retry_policy=None,
+            retry_policy=retry_policy_to_proto(opts.get("retry_policy")),
             header=None,
             request_local_dispatch=False,
         )

--- a/cadence/_internal/workflow/retry_policy.py
+++ b/cadence/_internal/workflow/retry_policy.py
@@ -1,0 +1,62 @@
+"""Adapt :class:`cadence.workflow.RetryPolicy` (TypedDict) to its protobuf wire form."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from math import ceil
+from typing import Mapping, cast
+
+from google.protobuf.duration_pb2 import Duration
+
+from cadence.api.v1 import common_pb2
+from cadence.workflow import RetryPolicy
+
+_round_to_whole_seconds = lambda delta: timedelta(seconds=ceil(delta.total_seconds()))
+
+def _set_duration_field(target: Duration, delta: timedelta) -> None:
+    """Write ``delta``, ceil-rounded to whole seconds, into a proto ``Duration`` field."""
+    d = Duration()
+    d.FromTimedelta(_round_to_whole_seconds(delta))
+    target.CopyFrom(d)
+
+
+def retry_policy_to_proto(
+    policy: RetryPolicy | Mapping[str, object] | None,
+) -> common_pb2.RetryPolicy | None:
+    """Convert a user retry policy to protobuf, or ``None`` if no policy was provided.
+
+    ``None`` and an empty mapping both map to ``None`` so that the server applies its
+    own defaults instead of receiving an explicit empty policy. Durations are ceiled
+    to whole seconds to match the server's resolution and the Go/Java SDKs.
+    """
+    if policy is None or (isinstance(policy, Mapping) and len(policy) == 0):
+        return None
+
+    out = common_pb2.RetryPolicy()
+
+    if "initial_interval" in policy:
+        _set_duration_field(
+            out.initial_interval, cast(timedelta, policy["initial_interval"])
+        )
+
+    if "backoff_coefficient" in policy:
+        coef = cast(float, policy["backoff_coefficient"])
+        if coef < 1.0:
+            raise ValueError("backoff_coefficient must be >= 1.0 when provided")
+        out.backoff_coefficient = coef
+
+    if (mi := policy.get("maximum_interval")) is not None:
+        _set_duration_field(out.maximum_interval, cast(timedelta, mi))
+
+    if "maximum_attempts" in policy:
+        out.maximum_attempts = int(cast(int, policy["maximum_attempts"]))
+
+    if "non_retryable_error_reasons" in policy:
+        out.non_retryable_error_reasons.extend(
+            cast(list[str], policy["non_retryable_error_reasons"])
+        )
+
+    if (ei := policy.get("expiration_interval")) is not None:
+        _set_duration_field(out.expiration_interval, cast(timedelta, ei))
+
+    return out

--- a/cadence/_internal/workflow/retry_policy.py
+++ b/cadence/_internal/workflow/retry_policy.py
@@ -11,7 +11,11 @@ from google.protobuf.duration_pb2 import Duration
 from cadence.api.v1 import common_pb2
 from cadence.workflow import RetryPolicy
 
-_round_to_whole_seconds = lambda delta: timedelta(seconds=ceil(delta.total_seconds()))
+
+def _round_to_whole_seconds(delta: timedelta) -> timedelta:
+    """Ceil-round a ``timedelta`` to whole seconds."""
+    return timedelta(seconds=ceil(delta.total_seconds()))
+
 
 def _set_duration_field(target: Duration, delta: timedelta) -> None:
     """Write ``delta``, ceil-rounded to whole seconds, into a proto ``Duration`` field."""
@@ -34,27 +38,23 @@ def retry_policy_to_proto(
 
     out = common_pb2.RetryPolicy()
 
-    if "initial_interval" in policy:
-        _set_duration_field(
-            out.initial_interval, cast(timedelta, policy["initial_interval"])
-        )
+    if (ii := policy.get("initial_interval")) is not None:
+        _set_duration_field(out.initial_interval, cast(timedelta, ii))
 
-    if "backoff_coefficient" in policy:
-        coef = cast(float, policy["backoff_coefficient"])
-        if coef < 1.0:
+    if (coef := policy.get("backoff_coefficient")) is not None:
+        coef_f = cast(float, coef)
+        if coef_f < 1.0:
             raise ValueError("backoff_coefficient must be >= 1.0 when provided")
-        out.backoff_coefficient = coef
+        out.backoff_coefficient = coef_f
 
     if (mi := policy.get("maximum_interval")) is not None:
         _set_duration_field(out.maximum_interval, cast(timedelta, mi))
 
-    if "maximum_attempts" in policy:
-        out.maximum_attempts = int(cast(int, policy["maximum_attempts"]))
+    if (ma := policy.get("maximum_attempts")) is not None:
+        out.maximum_attempts = int(cast(int, ma))
 
-    if "non_retryable_error_reasons" in policy:
-        out.non_retryable_error_reasons.extend(
-            cast(list[str], policy["non_retryable_error_reasons"])
-        )
+    if (reasons := policy.get("non_retryable_error_reasons")) is not None:
+        out.non_retryable_error_reasons.extend(cast(list[str], reasons))
 
     if (ei := policy.get("expiration_interval")) is not None:
         _set_duration_field(out.expiration_interval, cast(timedelta, ei))

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -27,12 +27,22 @@ from cadence.signal import SignalDefinition, SignalDefinitionOptions
 ResultType = TypeVar("ResultType")
 
 
+class RetryPolicy(TypedDict, total=False):
+    initial_interval: timedelta
+    backoff_coefficient: float
+    maximum_interval: timedelta
+    maximum_attempts: int
+    non_retryable_error_reasons: list[str]
+    expiration_interval: timedelta
+
+
 class ActivityOptions(TypedDict, total=False):
     task_list: str
     schedule_to_close_timeout: timedelta
     schedule_to_start_timeout: timedelta
     start_to_close_timeout: timedelta
     heartbeat_timeout: timedelta
+    retry_policy: RetryPolicy
 
 
 async def execute_activity(

--- a/tests/cadence/_internal/workflow/test_context_retry_policy.py
+++ b/tests/cadence/_internal/workflow/test_context_retry_policy.py
@@ -1,0 +1,53 @@
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from google.protobuf.duration_pb2 import Duration
+
+from cadence._internal.workflow.context import Context
+from cadence.api.v1.common_pb2 import ActivityType
+from cadence.api.v1.decision_pb2 import ScheduleActivityTaskDecisionAttributes
+from cadence.api.v1.tasklist_pb2 import TaskList, TaskListKind
+from cadence.data_converter import DefaultDataConverter
+from cadence.workflow import WorkflowInfo
+
+
+@pytest.mark.asyncio
+async def test_execute_activity_passes_retry_policy_to_schedule():
+    dm = MagicMock()
+    dm.schedule_activity = AsyncMock(
+        return_value=DefaultDataConverter().to_data(["result"])
+    )
+
+    info = WorkflowInfo(
+        workflow_type="Wf",
+        workflow_domain="domain",
+        workflow_id="wid",
+        workflow_run_id="rid",
+        workflow_task_list="tl",
+        data_converter=DefaultDataConverter(),
+    )
+    ctx = Context(info, dm)
+
+    await ctx.execute_activity(
+        "Act",
+        str,
+        retry_policy={
+            "initial_interval": timedelta(seconds=2),
+            "backoff_coefficient": 2.0,
+            "maximum_attempts": 3,
+        },
+    )
+
+    dm.schedule_activity.assert_awaited_once()
+    attrs: ScheduleActivityTaskDecisionAttributes = dm.schedule_activity.call_args[0][0]
+    assert attrs.activity_type == ActivityType(name="Act")
+    assert attrs.domain == "domain"
+    assert attrs.task_list == TaskList(
+        kind=TaskListKind.TASK_LIST_KIND_NORMAL, name="tl"
+    )
+    rp = attrs.retry_policy
+    assert rp is not None
+    assert rp.initial_interval == Duration(seconds=2)
+    assert rp.backoff_coefficient == 2.0
+    assert rp.maximum_attempts == 3

--- a/tests/cadence/_internal/workflow/test_retry_policy.py
+++ b/tests/cadence/_internal/workflow/test_retry_policy.py
@@ -64,3 +64,24 @@ def test_retry_policy_backoff_omitted_not_explicitly_set_in_dict():
     assert p is not None
     d = MessageToDict(p, preserving_proto_field_name=True)
     assert "backoff_coefficient" not in d
+
+
+def test_retry_policy_explicit_none_fields_are_omitted():
+    p = retry_policy_to_proto(
+        {
+            "initial_interval": None,
+            "backoff_coefficient": None,
+            "maximum_interval": None,
+            "maximum_attempts": None,
+            "non_retryable_error_reasons": None,
+            "expiration_interval": None,
+        }
+    )
+    assert p is not None
+    assert not p.HasField("initial_interval")
+    assert not p.HasField("maximum_interval")
+    assert not p.HasField("expiration_interval")
+    d = MessageToDict(p, preserving_proto_field_name=True)
+    assert "backoff_coefficient" not in d
+    assert "maximum_attempts" not in d
+    assert "non_retryable_error_reasons" not in d

--- a/tests/cadence/_internal/workflow/test_retry_policy.py
+++ b/tests/cadence/_internal/workflow/test_retry_policy.py
@@ -1,0 +1,66 @@
+from datetime import timedelta
+
+import pytest
+from google.protobuf.json_format import MessageToDict
+
+from cadence._internal.workflow.retry_policy import retry_policy_to_proto
+
+
+def test_retry_policy_none_and_empty():
+    assert retry_policy_to_proto(None) is None
+    assert retry_policy_to_proto({}) is None
+
+
+def test_retry_policy_rounds_durations_up_to_seconds():
+    p = retry_policy_to_proto(
+        {
+            "initial_interval": timedelta(milliseconds=500),
+            "maximum_interval": timedelta(seconds=2, microseconds=1),
+            "expiration_interval": timedelta(seconds=30),
+        }
+    )
+    assert p is not None
+    assert p.initial_interval.seconds == 1
+    assert p.maximum_interval.seconds == 3
+    assert p.expiration_interval.seconds == 30
+
+
+def test_retry_policy_maximum_interval_none_omits_field():
+    p = retry_policy_to_proto(
+        {
+            "initial_interval": timedelta(seconds=1),
+            "maximum_interval": None,
+        }
+    )
+    assert p is not None
+    assert not p.HasField("maximum_interval")
+
+
+def test_retry_policy_backoff_coefficient_validation():
+    with pytest.raises(ValueError, match="backoff_coefficient"):
+        retry_policy_to_proto({"backoff_coefficient": 0.5})
+
+    p = retry_policy_to_proto(
+        {"backoff_coefficient": 1.0, "initial_interval": timedelta(seconds=1)}
+    )
+    assert p is not None
+    assert p.backoff_coefficient == 1.0
+
+
+def test_retry_policy_maximum_attempts_and_non_retryable():
+    p = retry_policy_to_proto(
+        {
+            "maximum_attempts": 0,
+            "non_retryable_error_reasons": ["a", "b"],
+        }
+    )
+    assert p is not None
+    assert p.maximum_attempts == 0
+    assert list(p.non_retryable_error_reasons) == ["a", "b"]
+
+
+def test_retry_policy_backoff_omitted_not_explicitly_set_in_dict():
+    p = retry_policy_to_proto({"initial_interval": timedelta(seconds=1)})
+    assert p is not None
+    d = MessageToDict(p, preserving_proto_field_name=True)
+    assert "backoff_coefficient" not in d


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**

----
## Summary by Gitar

- **New functionality:**
  - Defined `RetryPolicy` `TypedDict` and integrated it into `ActivityOptions` for activity execution.
  - Implemented `retry_policy_to_proto` to convert user-defined policies into protobuf format, including automatic duration ceiling to whole seconds.
- **Code refactoring:**
  - Refactored `Context` to use a centralized `_DEFAULT_ACTIVITY_OPTIONS` constant for better maintainability.
- **Test coverage:**
  - Added comprehensive unit tests in `test_retry_policy.py` and `test_context_retry_policy.py` to verify protobuf mapping, duration rounding, and validation logic.

<sub>This will update automatically on new commits.</sub>