### PR TITLE
feat: implement wfIDReusePolicy feature

### DIFF
--- a/cadence/client.py
+++ b/cadence/client.py
@@ -43,10 +43,19 @@ class StartWorkflowOptions(TypedDict, total=False):
     jitter_start: timedelta
     cron_overlap_policy: workflow_pb2.CronOverlapPolicy
     first_run_at: datetime
+    workflow_id_reuse_policy: workflow_pb2.WorkflowIdReusePolicy
 
 
-def _validate_and_apply_defaults(options: StartWorkflowOptions) -> StartWorkflowOptions:
-    """Validate required fields and apply defaults to StartWorkflowOptions."""
+def _validate_and_apply_defaults(
+    options: StartWorkflowOptions,
+    default_workflow_id_reuse_policy: workflow_pb2.WorkflowIdReusePolicy = workflow_pb2.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+) -> StartWorkflowOptions:
+    """Validate required fields and apply defaults to StartWorkflowOptions.
+
+    ``default_workflow_id_reuse_policy`` defaults to the value used by
+    ``start_workflow``. ``signal_with_start_workflow`` passes
+    ``ALLOW_DUPLICATE`` for Go parity.
+    """
     if not options.get("task_list"):
         raise ValueError("task_list is required")
 
@@ -72,6 +81,16 @@ def _validate_and_apply_defaults(options: StartWorkflowOptions) -> StartWorkflow
     jitter_start = options.get("jitter_start")
     if jitter_start is not None and jitter_start < timedelta(0):
         raise ValueError("jitter_start cannot be negative")
+
+    if options.get("workflow_id_reuse_policy") is None:
+        options["workflow_id_reuse_policy"] = default_workflow_id_reuse_policy
+    elif (
+        options["workflow_id_reuse_policy"]
+        == workflow_pb2.WORKFLOW_ID_REUSE_POLICY_INVALID
+    ):
+        raise ValueError(
+            "workflow_id_reuse_policy cannot be WORKFLOW_ID_REUSE_POLICY_INVALID"
+        )
 
     # Validate first_run_at (must be timezone-aware and not before Unix epoch)
     first_run_at = options.get("first_run_at")
@@ -220,6 +239,8 @@ class Client:
             request.cron_schedule = options["cron_schedule"]
         if options.get("cron_overlap_policy") is not None:
             request.cron_overlap_policy = options["cron_overlap_policy"]
+        if options.get("workflow_id_reuse_policy") is not None:
+            request.workflow_id_reuse_policy = options["workflow_id_reuse_policy"]
 
         # Set delay_start if provided
         delay_start = options.get("delay_start")
@@ -360,7 +381,10 @@ class Client:
             Exception: If the gRPC call fails
         """
         # Convert kwargs to StartWorkflowOptions and validate
-        options = _validate_and_apply_defaults(StartWorkflowOptions(**options_kwargs))
+        options = _validate_and_apply_defaults(
+            StartWorkflowOptions(**options_kwargs),
+            workflow_pb2.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+        )
 
         # Build the start workflow request
         start_request = self._build_start_workflow_request(

--- a/tests/cadence/test_client_workflow.py
+++ b/tests/cadence/test_client_workflow.py
@@ -674,6 +674,7 @@ class TestClientStartWorkflow:
                 workflow_id_reuse_policy=workflow_pb2.WORKFLOW_ID_REUSE_POLICY_INVALID,
             )
 
+
 @pytest.mark.asyncio
 async def test_integration_workflow_invocation():
     """Integration test for workflow invocation flow."""

--- a/tests/cadence/test_client_workflow.py
+++ b/tests/cadence/test_client_workflow.py
@@ -415,6 +415,48 @@ class TestClientBuildStartWorkflowRequest:
             1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc
         )
 
+    @pytest.mark.parametrize(
+        "policy",
+        [
+            workflow_pb2.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+            workflow_pb2.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+            workflow_pb2.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+            workflow_pb2.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+        ],
+        ids=[
+            "allow_duplicate_failed_only",
+            "allow_duplicate",
+            "reject_duplicate",
+            "terminate_if_running",
+        ],
+    )
+    def test_build_request_propagates_workflow_id_reuse_policy(
+        self, policy: workflow_pb2.WorkflowIdReusePolicy
+    ) -> None:
+        """Non-INVALID reuse policies propagate through the builder."""
+        client = Client(domain="test-domain", target="localhost:7933")
+        options = StartWorkflowOptions(
+            task_list="test-task-list",
+            execution_start_to_close_timeout=timedelta(minutes=10),
+            task_start_to_close_timeout=timedelta(seconds=30),
+            workflow_id_reuse_policy=policy,
+        )
+        request = client._build_start_workflow_request("TestWorkflow", (), options)
+        assert request.workflow_id_reuse_policy == policy
+
+    def test_invalid_workflow_id_reuse_policy_raises_error(self):
+        """Explicit WORKFLOW_ID_REUSE_POLICY_INVALID is rejected."""
+        options = StartWorkflowOptions(
+            task_list="test-task-list",
+            execution_start_to_close_timeout=timedelta(minutes=10),
+            workflow_id_reuse_policy=workflow_pb2.WORKFLOW_ID_REUSE_POLICY_INVALID,
+        )
+        with pytest.raises(
+            ValueError,
+            match="workflow_id_reuse_policy cannot be WORKFLOW_ID_REUSE_POLICY_INVALID",
+        ):
+            _validate_and_apply_defaults(options)
+
 
 class TestClientStartWorkflow:
     """Test Client.start_workflow method."""
@@ -560,6 +602,77 @@ class TestClientStartWorkflow:
         # Verify default was applied
         assert captured_options["task_start_to_close_timeout"] == timedelta(seconds=10)
 
+    @pytest.mark.asyncio
+    async def test_start_workflow_defaults_reuse_policy_to_allow_duplicate_failed_only(
+        self, mock_client
+    ):
+        """start_workflow defaults workflow_id_reuse_policy to ALLOW_DUPLICATE_FAILED_ONLY."""
+        response = StartWorkflowExecutionResponse()
+        response.run_id = "test-run-id"
+
+        mock_client.workflow_stub.StartWorkflowExecution = AsyncMock(
+            return_value=response
+        )
+
+        client = Client(domain="test-domain", target="localhost:7933")
+        client._workflow_stub = mock_client.workflow_stub
+
+        await client.start_workflow(
+            "TestWorkflow",
+            task_list="test-task-list",
+            execution_start_to_close_timeout=timedelta(minutes=10),
+            task_start_to_close_timeout=timedelta(seconds=30),
+        )
+
+        request = mock_client.workflow_stub.StartWorkflowExecution.call_args[0][0]
+        assert (
+            request.workflow_id_reuse_policy
+            == workflow_pb2.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_workflow_respects_explicit_reuse_policy(self, mock_client):
+        """Explicit workflow_id_reuse_policy on start_workflow overrides the default."""
+        response = StartWorkflowExecutionResponse()
+        response.run_id = "test-run-id"
+
+        mock_client.workflow_stub.StartWorkflowExecution = AsyncMock(
+            return_value=response
+        )
+
+        client = Client(domain="test-domain", target="localhost:7933")
+        client._workflow_stub = mock_client.workflow_stub
+
+        await client.start_workflow(
+            "TestWorkflow",
+            task_list="test-task-list",
+            execution_start_to_close_timeout=timedelta(minutes=10),
+            task_start_to_close_timeout=timedelta(seconds=30),
+            workflow_id_reuse_policy=workflow_pb2.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+        )
+
+        request = mock_client.workflow_stub.StartWorkflowExecution.call_args[0][0]
+        assert (
+            request.workflow_id_reuse_policy
+            == workflow_pb2.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_workflow_rejects_invalid_reuse_policy(self, mock_client):
+        """Explicit WORKFLOW_ID_REUSE_POLICY_INVALID on start_workflow raises ValueError."""
+        client = Client(domain="test-domain", target="localhost:7933")
+
+        with pytest.raises(
+            ValueError,
+            match="workflow_id_reuse_policy cannot be WORKFLOW_ID_REUSE_POLICY_INVALID",
+        ):
+            await client.start_workflow(
+                "TestWorkflow",
+                task_list="test-task-list",
+                execution_start_to_close_timeout=timedelta(minutes=10),
+                task_start_to_close_timeout=timedelta(seconds=30),
+                workflow_id_reuse_policy=workflow_pb2.WORKFLOW_ID_REUSE_POLICY_INVALID,
+            )
 
 @pytest.mark.asyncio
 async def test_integration_workflow_invocation():

--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -1,15 +1,20 @@
 import pytest
 from datetime import timedelta
 
+from cadence.api.v1 import workflow_pb2
 from cadence.api.v1.service_domain_pb2 import (
     DescribeDomainRequest,
     DescribeDomainResponse,
 )
-from cadence.error import EntityNotExistsError
+from cadence.error import (
+    EntityNotExistsError,
+    WorkflowExecutionAlreadyStartedError,
+)
 from tests.integration_tests.helper import CadenceHelper, DOMAIN_NAME
 from cadence.api.v1.service_workflow_pb2 import (
     DescribeWorkflowExecutionRequest,
     GetWorkflowExecutionHistoryRequest,
+    TerminateWorkflowExecutionRequest,
 )
 from cadence.api.v1.common_pb2 import WorkflowExecution
 
@@ -193,6 +198,80 @@ async def test_signal_workflow(helper: CadenceHelper):
             signal_event.workflow_execution_signaled_event_attributes.signal_name
             == signal_name
         ), f"Expected signal name '{signal_name}'"
+
+
+@pytest.mark.usefixtures("helper")
+async def test_workflow_id_reuse_policy_reject_duplicate(helper: CadenceHelper):
+    """REJECT_DUPLICATE propagates to server and blocks a second start with the same workflow_id.
+
+    This verifies end-to-end that:
+    1. The workflow_id_reuse_policy option reaches the Cadence server.
+    2. REJECT_DUPLICATE actually causes the server to reject a duplicate start.
+    """
+    async with helper.client() as client:
+        workflow_type = "test-workflow-reuse-reject"
+        task_list_name = "test-task-list-reuse-reject"
+        workflow_id = "test-workflow-reuse-reject-id"
+        execution_timeout = timedelta(minutes=5)
+
+        first_execution = await client.start_workflow(
+            workflow_type,
+            task_list=task_list_name,
+            execution_start_to_close_timeout=execution_timeout,
+            workflow_id=workflow_id,
+        )
+
+        # Terminate the first run so the second start fails on reuse-policy
+        # rather than on "workflow already running".
+        await client.workflow_stub.TerminateWorkflowExecution(
+            TerminateWorkflowExecutionRequest(
+                domain=DOMAIN_NAME,
+                workflow_execution=WorkflowExecution(
+                    workflow_id=first_execution.workflow_id,
+                    run_id=first_execution.run_id,
+                ),
+                reason="test cleanup for reuse-policy test",
+                identity=client.identity,
+            )
+        )
+
+        with pytest.raises(WorkflowExecutionAlreadyStartedError):
+            await client.start_workflow(
+                workflow_type,
+                task_list=task_list_name,
+                execution_start_to_close_timeout=execution_timeout,
+                workflow_id=workflow_id,
+                workflow_id_reuse_policy=workflow_pb2.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+            )
+
+
+@pytest.mark.usefixtures("helper")
+async def test_workflow_id_reuse_policy_terminate_if_running(helper: CadenceHelper):
+    """TERMINATE_IF_RUNNING propagates and causes the server to terminate the prior run."""
+    async with helper.client() as client:
+        workflow_type = "test-workflow-reuse-terminate"
+        task_list_name = "test-task-list-reuse-terminate"
+        workflow_id = "test-workflow-reuse-terminate-id"
+        execution_timeout = timedelta(minutes=5)
+
+        first_execution = await client.start_workflow(
+            workflow_type,
+            task_list=task_list_name,
+            execution_start_to_close_timeout=execution_timeout,
+            workflow_id=workflow_id,
+        )
+
+        second_execution = await client.start_workflow(
+            workflow_type,
+            task_list=task_list_name,
+            execution_start_to_close_timeout=execution_timeout,
+            workflow_id=workflow_id,
+            workflow_id_reuse_policy=workflow_pb2.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+        )
+
+        assert second_execution.workflow_id == workflow_id
+        assert second_execution.run_id != ""
+        assert second_execution.run_id != first_execution.run_id
 
 
 @pytest.mark.usefixtures("helper")


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
implement wfIDReusePolicy feature by parsing the option into startWorkflowOption

<!-- Tell your future self why have you made these changes -->
**Why?**
wfIDReusePolicy is a crucial feature.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Uni test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**

----
## Summary by Gitar

- **Validation logic:**
  - Added `_validate_and_apply_defaults` logic to reject `WORKFLOW_ID_REUSE_POLICY_INVALID` values.
  - Set default reuse policy to `ALLOW_DUPLICATE_FAILED_ONLY` in `start_workflow`.
- **Integration testing:**
  - Added end-to-end tests for `REJECT_DUPLICATE` and `TERMINATE_IF_RUNNING` policies using `integration_tests/test_client.py`.

<sub>This will update automatically on new commits.</sub>