### PR TITLE
fix: fix makefile with extra dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ pr: install generate lint type-check test integration-test
 # Install dependencies
 install:
 	@echo "Installing dependencies..."
-	uv sync --extra dev
+	uv sync --all-extras
 
 # Generate idl files
 generate:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We added a openai dependency, causing makefile to fail since it did not import openai dependency.

<!-- Tell your future self why have you made these changes -->
**Why?**
we need makefile to run

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
run `make`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**