### PR TITLE
feat: workflow retry

### DIFF
--- a/cadence/client.py
+++ b/cadence/client.py
@@ -11,6 +11,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from cadence._internal.rpc.error import CadenceErrorInterceptor
 from cadence._internal.rpc.retry import RetryInterceptor
 from cadence._internal.rpc.yarpc import YarpcMetadataInterceptor
+from cadence._internal.workflow.retry_policy import retry_policy_to_proto
 from cadence.api.v1.service_domain_pb2_grpc import DomainAPIStub
 from cadence.api.v1.service_worker_pb2_grpc import WorkerAPIStub
 import grpc.aio
@@ -28,7 +29,7 @@ from cadence.api.v1 import workflow_pb2
 from cadence.api.v1.tasklist_pb2 import TaskList
 from cadence.data_converter import DataConverter, DefaultDataConverter
 from cadence.metrics import MetricsEmitter, NoOpMetricsEmitter
-from cadence.workflow import WorkflowDefinition
+from cadence.workflow import RetryPolicy, WorkflowDefinition
 
 
 class StartWorkflowOptions(TypedDict, total=False):
@@ -44,6 +45,7 @@ class StartWorkflowOptions(TypedDict, total=False):
     cron_overlap_policy: workflow_pb2.CronOverlapPolicy
     first_run_at: datetime
     workflow_id_reuse_policy: workflow_pb2.WorkflowIdReusePolicy
+    retry_policy: RetryPolicy
 
 
 def _validate_and_apply_defaults(
@@ -262,6 +264,11 @@ class Client:
             first_run_timestamp = Timestamp()
             first_run_timestamp.FromDatetime(first_run_at)
             request.first_run_at.CopyFrom(first_run_timestamp)
+
+        # Set retry_policy if provided
+        retry_proto = retry_policy_to_proto(options.get("retry_policy"))
+        if retry_proto is not None:
+            request.retry_policy.CopyFrom(retry_proto)
 
         return request
 

--- a/tests/cadence/test_client_workflow.py
+++ b/tests/cadence/test_client_workflow.py
@@ -733,9 +733,7 @@ class TestBuildStartWorkflowRequestRetryPolicy:
     def test_retry_policy_omitted_sets_no_field(self):
         """No retry_policy → request has no retry_policy field."""
         client = self._client()
-        request = client._build_start_workflow_request(
-            "WF", (), self._base_options()
-        )
+        request = client._build_start_workflow_request("WF", (), self._base_options())
         assert not request.HasField("retry_policy")
 
     def test_retry_policy_empty_dict_sets_no_field(self):

--- a/tests/cadence/test_client_workflow.py
+++ b/tests/cadence/test_client_workflow.py
@@ -7,6 +7,7 @@ from cadence.api.v1.common_pb2 import WorkflowExecution
 from cadence.api.v1.service_workflow_pb2 import (
     StartWorkflowExecutionRequest,
     StartWorkflowExecutionResponse,
+    SignalWithStartWorkflowExecutionResponse,
 )
 from cadence.client import (
     Client,
@@ -713,3 +714,137 @@ async def test_integration_workflow_invocation():
     assert request.task_list.name == "integration-task-list"
     assert request.HasField("input")  # Should have encoded input
     assert request.HasField("execution_start_to_close_timeout")
+
+
+class TestBuildStartWorkflowRequestRetryPolicy:
+    """Tests for retry_policy wiring in _build_start_workflow_request."""
+
+    def _base_options(self, **extra) -> StartWorkflowOptions:
+        return StartWorkflowOptions(
+            task_list="test-task-list",
+            execution_start_to_close_timeout=timedelta(minutes=10),
+            task_start_to_close_timeout=timedelta(seconds=30),
+            **extra,
+        )
+
+    def _client(self) -> Client:
+        return Client(domain="test-domain", target="localhost:7933")
+
+    def test_retry_policy_omitted_sets_no_field(self):
+        """No retry_policy → request has no retry_policy field."""
+        client = self._client()
+        request = client._build_start_workflow_request(
+            "WF", (), self._base_options()
+        )
+        assert not request.HasField("retry_policy")
+
+    def test_retry_policy_empty_dict_sets_no_field(self):
+        """Empty dict retry_policy → treated as None, no field set."""
+        client = self._client()
+        request = client._build_start_workflow_request(
+            "WF", (), self._base_options(retry_policy={})
+        )
+        assert not request.HasField("retry_policy")
+
+    def test_retry_policy_populated_sets_field(self):
+        """Populated retry_policy → request.retry_policy is set."""
+        client = self._client()
+        request = client._build_start_workflow_request(
+            "WF",
+            (),
+            self._base_options(
+                retry_policy={
+                    "initial_interval": timedelta(seconds=1),
+                    "backoff_coefficient": 2.0,
+                    "maximum_interval": timedelta(seconds=10),
+                    "maximum_attempts": 3,
+                    "non_retryable_error_reasons": ["FatalError"],
+                    "expiration_interval": timedelta(minutes=5),
+                }
+            ),
+        )
+        assert request.HasField("retry_policy")
+        rp = request.retry_policy
+        assert rp.initial_interval.seconds == 1
+        assert rp.backoff_coefficient == 2.0
+        assert rp.maximum_interval.seconds == 10
+        assert rp.maximum_attempts == 3
+        assert list(rp.non_retryable_error_reasons) == ["FatalError"]
+        assert rp.expiration_interval.seconds == 300
+
+    def test_retry_policy_duration_ceiled_to_seconds(self):
+        """Sub-second durations are ceil-rounded to whole seconds."""
+        client = self._client()
+        request = client._build_start_workflow_request(
+            "WF",
+            (),
+            self._base_options(
+                retry_policy={"initial_interval": timedelta(milliseconds=500)}
+            ),
+        )
+        assert request.HasField("retry_policy")
+        assert request.retry_policy.initial_interval.seconds == 1
+
+    def test_retry_policy_invalid_backoff_raises(self):
+        """backoff_coefficient < 1.0 raises ValueError at build time."""
+        client = self._client()
+        with pytest.raises(ValueError, match="backoff_coefficient"):
+            client._build_start_workflow_request(
+                "WF",
+                (),
+                self._base_options(retry_policy={"backoff_coefficient": 0.5}),
+            )
+
+    @pytest.mark.asyncio
+    async def test_start_workflow_passes_retry_policy_to_server(self):
+        """start_workflow wires retry_policy into the gRPC request sent to the server."""
+        response = StartWorkflowExecutionResponse()
+        response.run_id = "run-1"
+
+        client = Client(domain="test-domain", target="localhost:7933")
+        client._workflow_stub = Mock()
+        client._workflow_stub.StartWorkflowExecution = AsyncMock(return_value=response)
+
+        await client.start_workflow(
+            "WF",
+            task_list="tl",
+            execution_start_to_close_timeout=timedelta(minutes=5),
+            retry_policy={
+                "initial_interval": timedelta(seconds=2),
+                "maximum_attempts": 4,
+            },
+        )
+
+        request = client._workflow_stub.StartWorkflowExecution.call_args[0][0]
+        assert request.HasField("retry_policy")
+        assert request.retry_policy.initial_interval.seconds == 2
+        assert request.retry_policy.maximum_attempts == 4
+
+    @pytest.mark.asyncio
+    async def test_signal_with_start_workflow_passes_retry_policy(self):
+        """signal_with_start_workflow wires retry_policy into the underlying start request."""
+        response = SignalWithStartWorkflowExecutionResponse()
+        response.run_id = "run-2"
+
+        client = Client(domain="test-domain", target="localhost:7933")
+        client._workflow_stub = Mock()
+        client._workflow_stub.SignalWithStartWorkflowExecution = AsyncMock(
+            return_value=response
+        )
+
+        await client.signal_with_start_workflow(
+            "WF",
+            "my-signal",
+            [],
+            task_list="tl",
+            execution_start_to_close_timeout=timedelta(minutes=5),
+            retry_policy={
+                "initial_interval": timedelta(seconds=3),
+                "maximum_attempts": 2,
+            },
+        )
+
+        request = client._workflow_stub.SignalWithStartWorkflowExecution.call_args[0][0]
+        assert request.start_request.HasField("retry_policy")
+        assert request.start_request.retry_policy.initial_interval.seconds == 3
+        assert request.start_request.retry_policy.maximum_attempts == 2

--- a/tests/integration_tests/workflow/test_retry_policy.py
+++ b/tests/integration_tests/workflow/test_retry_policy.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 
 from cadence import workflow, Registry, activity
+from cadence.api.v1 import workflow_pb2
+from cadence.api.v1.common_pb2 import WorkflowExecution
 from cadence.api.v1.history_pb2 import EventFilterType
 from cadence.api.v1.service_workflow_pb2 import (
     GetWorkflowExecutionHistoryRequest,
@@ -151,4 +153,186 @@ async def test_non_retryable_error_skips_retries(helper: CadenceHelper):
         ]
         assert not completed_events, (
             "non-retryable error should not produce a successful completion"
+        )
+
+
+wf_retry_registry = Registry()
+
+
+class AlwaysFailsError(Exception):
+    """Always raised by the failing workflow."""
+
+
+class NonRetryableWorkflowError(Exception):
+    """Listed in non_retryable_error_reasons to block retries."""
+
+
+@wf_retry_registry.workflow()
+class AlwaysFailsWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        raise AlwaysFailsError("workflow always fails")
+
+
+@wf_retry_registry.workflow()
+class NonRetryableWorkflowErrorWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        raise NonRetryableWorkflowError("non-retryable")
+
+
+async def _wait_for_close(
+    helper: CadenceHelper,
+    execution: WorkflowExecution,
+) -> GetWorkflowExecutionHistoryResponse:
+    """Block until the given run reaches a terminal (close) event.
+
+    This is a server-side long-poll — the server holds the request open until
+    a close event lands, so there is no client-side sleep or polling loop.
+    """
+    async with helper.client() as client:
+        return await client.workflow_stub.GetWorkflowExecutionHistory(
+            GetWorkflowExecutionHistoryRequest(
+                domain=DOMAIN_NAME,
+                workflow_execution=execution,
+                wait_for_new_event=True,
+                history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_CLOSE_EVENT,
+                skip_archival=True,
+            )
+        )
+
+
+async def test_workflow_retries_on_failure(helper: CadenceHelper):
+    """Server retries the workflow when retry_policy is set and the run fails.
+
+    With maximum_attempts=2 the first run fails and is continued-as-new with
+    RETRY_POLICY initiator, and the second run also fails (terminal).  We verify
+    the chain of runs in history.
+    """
+    async with helper.worker(wf_retry_registry) as worker:
+        execution = await worker.client.start_workflow(
+            "AlwaysFailsWorkflow",
+            task_list=worker.task_list,
+            execution_start_to_close_timeout=timedelta(seconds=30),
+            retry_policy={
+                "initial_interval": timedelta(seconds=1),
+                "backoff_coefficient": 1.0,
+                "maximum_interval": timedelta(seconds=1),
+                "maximum_attempts": 2,
+            },
+        )
+
+        # Wait for the *first* run to close (ContinuedAsNew or Failed)
+        first_close = await _wait_for_close(helper, execution)
+        first_close_event = first_close.history.events[-1]
+
+        # The first run must be continued-as-new with RETRY_POLICY initiator
+        assert first_close_event.HasField(
+            "workflow_execution_continued_as_new_event_attributes"
+        ), "Expected first run to be continued-as-new for retry"
+        can_attrs = (
+            first_close_event.workflow_execution_continued_as_new_event_attributes
+        )
+        assert (
+            can_attrs.initiator
+            == workflow_pb2.CONTINUE_AS_NEW_INITIATOR_RETRY_POLICY
+        ), f"Expected RETRY_POLICY initiator, got {can_attrs.initiator}"
+
+        # Walk to the second run and confirm it ends Failed (no more retries)
+        second_run_id = can_attrs.new_execution_run_id
+        second_run_execution = WorkflowExecution(
+            workflow_id=execution.workflow_id,
+            run_id=second_run_id,
+        )
+        second_close = await _wait_for_close(helper, second_run_execution)
+        second_close_event = second_close.history.events[-1]
+        assert second_close_event.HasField(
+            "workflow_execution_failed_event_attributes"
+        ), "Expected second run to fail (no more retries)"
+
+
+async def test_workflow_no_retry_when_policy_unset(helper: CadenceHelper):
+    """Without a retry_policy the workflow fails after a single run."""
+    async with helper.worker(wf_retry_registry) as worker:
+        execution = await worker.client.start_workflow(
+            "AlwaysFailsWorkflow",
+            task_list=worker.task_list,
+            execution_start_to_close_timeout=timedelta(seconds=30),
+        )
+
+        close = await _wait_for_close(helper, execution)
+        close_event = close.history.events[-1]
+
+        assert close_event.HasField(
+            "workflow_execution_failed_event_attributes"
+        ), "Expected single-run failure without retry_policy"
+        # No ContinuedAsNew event in history means the server never scheduled a retry
+        async with helper.client() as client:
+            full: GetWorkflowExecutionHistoryResponse = (
+                await client.workflow_stub.GetWorkflowExecutionHistory(
+                    GetWorkflowExecutionHistoryRequest(
+                        domain=DOMAIN_NAME,
+                        workflow_execution=execution,
+                        skip_archival=True,
+                    )
+                )
+            )
+        continued_events = [
+            e
+            for e in full.history.events
+            if e.HasField("workflow_execution_continued_as_new_event_attributes")
+        ]
+        assert not continued_events, (
+            "No continued-as-new event expected without retry_policy"
+        )
+
+
+async def test_workflow_non_retryable_error_skips_retries(helper: CadenceHelper):
+    """A workflow error whose class name is in non_retryable_error_reasons is not retried."""
+    async with helper.worker(wf_retry_registry) as worker:
+        execution = await worker.client.start_workflow(
+            "NonRetryableWorkflowErrorWorkflow",
+            task_list=worker.task_list,
+            execution_start_to_close_timeout=timedelta(seconds=30),
+            retry_policy={
+                "initial_interval": timedelta(seconds=1),
+                "backoff_coefficient": 1.0,
+                "maximum_attempts": 5,
+                "non_retryable_error_reasons": ["NonRetryableWorkflowError"],
+            },
+        )
+
+        close = await _wait_for_close(helper, execution)
+        close_event = close.history.events[-1]
+
+        assert close_event.HasField(
+            "workflow_execution_failed_event_attributes"
+        ), "Expected failure on first attempt"
+
+        # Verify the failure reason matches the exception class name
+        failure_reason = (
+            close_event.workflow_execution_failed_event_attributes.failure.reason
+        )
+        assert failure_reason == "NonRetryableWorkflowError", (
+            f"Expected reason 'NonRetryableWorkflowError', got '{failure_reason}'"
+        )
+
+        # Confirm no retry was triggered
+        async with helper.client() as client:
+            full: GetWorkflowExecutionHistoryResponse = (
+                await client.workflow_stub.GetWorkflowExecutionHistory(
+                    GetWorkflowExecutionHistoryRequest(
+                        domain=DOMAIN_NAME,
+                        workflow_execution=execution,
+                        skip_archival=True,
+                    )
+                )
+            )
+        continued_events = [
+            e
+            for e in full.history.events
+            if e.HasField("workflow_execution_continued_as_new_event_attributes")
+        ]
+        assert not continued_events, (
+            "Non-retryable error must not trigger a retry"
         )

--- a/tests/integration_tests/workflow/test_retry_policy.py
+++ b/tests/integration_tests/workflow/test_retry_policy.py
@@ -234,8 +234,7 @@ async def test_workflow_retries_on_failure(helper: CadenceHelper):
             first_close_event.workflow_execution_continued_as_new_event_attributes
         )
         assert (
-            can_attrs.initiator
-            == workflow_pb2.CONTINUE_AS_NEW_INITIATOR_RETRY_POLICY
+            can_attrs.initiator == workflow_pb2.CONTINUE_AS_NEW_INITIATOR_RETRY_POLICY
         ), f"Expected RETRY_POLICY initiator, got {can_attrs.initiator}"
 
         # Walk to the second run and confirm it ends Failed (no more retries)
@@ -263,9 +262,9 @@ async def test_workflow_no_retry_when_policy_unset(helper: CadenceHelper):
         close = await _wait_for_close(helper, execution)
         close_event = close.history.events[-1]
 
-        assert close_event.HasField(
-            "workflow_execution_failed_event_attributes"
-        ), "Expected single-run failure without retry_policy"
+        assert close_event.HasField("workflow_execution_failed_event_attributes"), (
+            "Expected single-run failure without retry_policy"
+        )
         # No ContinuedAsNew event in history means the server never scheduled a retry
         async with helper.client() as client:
             full: GetWorkflowExecutionHistoryResponse = (
@@ -305,9 +304,9 @@ async def test_workflow_non_retryable_error_skips_retries(helper: CadenceHelper)
         close = await _wait_for_close(helper, execution)
         close_event = close.history.events[-1]
 
-        assert close_event.HasField(
-            "workflow_execution_failed_event_attributes"
-        ), "Expected failure on first attempt"
+        assert close_event.HasField("workflow_execution_failed_event_attributes"), (
+            "Expected failure on first attempt"
+        )
 
         # Verify the failure reason matches the exception class name
         failure_reason = (
@@ -333,6 +332,4 @@ async def test_workflow_non_retryable_error_skips_retries(helper: CadenceHelper)
             for e in full.history.events
             if e.HasField("workflow_execution_continued_as_new_event_attributes")
         ]
-        assert not continued_events, (
-            "Non-retryable error must not trigger a retry"
-        )
+        assert not continued_events, "Non-retryable error must not trigger a retry"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Implement workflow retry layer

<!-- Tell your future self why have you made these changes -->
**Why?**
Must have feature

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**


Signed-off-by: Tim Li <ltim@uber.com>

----
## Summary by Gitar

- **Client API:**
  - Added `RetryPolicy` support to `StartWorkflowOptions` for `start_workflow` and `signal_with_start_workflow`.
- **Utilities:**
  - Implemented `retry_policy_to_proto` for gRPC field mapping and parameter validation.
- **Testing:**
  - Added exhaustive integration tests for retry behavior, including failure scenarios and non-retryable errors.
  - Added unit tests for request building logic and retry policy validation rules.

<sub>This will update automatically on new commits.</sub>