### PR TITLE
fix: typesafety failure on retry test

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -54,7 +54,7 @@ jobs:
           uv sync --extra dev --extra openai
       - name: Run mypy type checker
         run: |
-          uv run mypy cadence/
+          uv run mypy cadence/ tests/
 
   test:
     name: Unit Tests

--- a/tests/cadence/_internal/workflow/test_retry_policy.py
+++ b/tests/cadence/_internal/workflow/test_retry_policy.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Mapping, cast
+from typing import Mapping
 
 import pytest
 from google.protobuf.json_format import MessageToDict
@@ -27,15 +27,11 @@ def test_retry_policy_rounds_durations_up_to_seconds():
 
 
 def test_retry_policy_maximum_interval_none_omits_field():
-    p = retry_policy_to_proto(
-        cast(
-            Mapping[str, object],
-            {
-                "initial_interval": timedelta(seconds=1),
-                "maximum_interval": None,
-            },
-        )
-    )
+    policy: Mapping[str, object] = {
+        "initial_interval": timedelta(seconds=1),
+        "maximum_interval": None,
+    }
+    p = retry_policy_to_proto(policy)
     assert p is not None
     assert not p.HasField("maximum_interval")
 
@@ -71,19 +67,15 @@ def test_retry_policy_backoff_omitted_not_explicitly_set_in_dict():
 
 
 def test_retry_policy_explicit_none_fields_are_omitted():
-    p = retry_policy_to_proto(
-        cast(
-            Mapping[str, object],
-            {
-                "initial_interval": None,
-                "backoff_coefficient": None,
-                "maximum_interval": None,
-                "maximum_attempts": None,
-                "non_retryable_error_reasons": None,
-                "expiration_interval": None,
-            },
-        )
-    )
+    policy: Mapping[str, object] = {
+        "initial_interval": None,
+        "backoff_coefficient": None,
+        "maximum_interval": None,
+        "maximum_attempts": None,
+        "non_retryable_error_reasons": None,
+        "expiration_interval": None,
+    }
+    p = retry_policy_to_proto(policy)
     assert p is not None
     assert not p.HasField("initial_interval")
     assert not p.HasField("maximum_interval")

--- a/tests/cadence/_internal/workflow/test_retry_policy.py
+++ b/tests/cadence/_internal/workflow/test_retry_policy.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Mapping, cast
 
 import pytest
 from google.protobuf.json_format import MessageToDict
@@ -27,10 +28,13 @@ def test_retry_policy_rounds_durations_up_to_seconds():
 
 def test_retry_policy_maximum_interval_none_omits_field():
     p = retry_policy_to_proto(
-        {
-            "initial_interval": timedelta(seconds=1),
-            "maximum_interval": None,
-        }
+        cast(
+            Mapping[str, object],
+            {
+                "initial_interval": timedelta(seconds=1),
+                "maximum_interval": None,
+            },
+        )
     )
     assert p is not None
     assert not p.HasField("maximum_interval")
@@ -68,14 +72,17 @@ def test_retry_policy_backoff_omitted_not_explicitly_set_in_dict():
 
 def test_retry_policy_explicit_none_fields_are_omitted():
     p = retry_policy_to_proto(
-        {
-            "initial_interval": None,
-            "backoff_coefficient": None,
-            "maximum_interval": None,
-            "maximum_attempts": None,
-            "non_retryable_error_reasons": None,
-            "expiration_interval": None,
-        }
+        cast(
+            Mapping[str, object],
+            {
+                "initial_interval": None,
+                "backoff_coefficient": None,
+                "maximum_interval": None,
+                "maximum_attempts": None,
+                "non_retryable_error_reasons": None,
+                "expiration_interval": None,
+            },
+        )
     )
     assert p is not None
     assert not p.HasField("initial_interval")

--- a/tests/cadence/_internal/workflow/test_waiter.py
+++ b/tests/cadence/_internal/workflow/test_waiter.py
@@ -28,7 +28,8 @@ class TestWaiterPredicateAlreadyTrue:
         loop = make_loop()
         w = Waiter(lambda: True, loop)
         w.poll()
-        assert w.result() is None
+        assert w.exception() is None
+        w.result()
 
 
 class TestWaiterFalseBecomesTrue:
@@ -49,7 +50,8 @@ class TestWaiterFalseBecomesTrue:
         state["v"] = True
         assert w.poll() is True
         assert w.done()
-        assert w.result() is None
+        assert w.exception() is None
+        w.result()
 
     def test_already_done_poll_is_idempotent(self) -> None:
         """Polling an already-settled waiter always returns True without re-running predicate."""

--- a/tests/integration_tests/workflow/test_retry_policy.py
+++ b/tests/integration_tests/workflow/test_retry_policy.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import cast
 
 from cadence import workflow, Registry, activity
 from cadence.api.v1 import workflow_pb2
@@ -191,14 +192,17 @@ async def _wait_for_close(
     a close event lands, so there is no client-side sleep or polling loop.
     """
     async with helper.client() as client:
-        return await client.workflow_stub.GetWorkflowExecutionHistory(
-            GetWorkflowExecutionHistoryRequest(
-                domain=DOMAIN_NAME,
-                workflow_execution=execution,
-                wait_for_new_event=True,
-                history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_CLOSE_EVENT,
-                skip_archival=True,
-            )
+        return cast(
+            GetWorkflowExecutionHistoryResponse,
+            await client.workflow_stub.GetWorkflowExecutionHistory(
+                GetWorkflowExecutionHistoryRequest(
+                    domain=DOMAIN_NAME,
+                    workflow_execution=execution,
+                    wait_for_new_event=True,
+                    history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_CLOSE_EVENT,
+                    skip_archival=True,
+                )
+            ),
         )
 
 

--- a/tests/integration_tests/workflow/test_retry_policy.py
+++ b/tests/integration_tests/workflow/test_retry_policy.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import cast
 
 from cadence import workflow, Registry, activity
 from cadence.api.v1 import workflow_pb2
@@ -192,18 +191,16 @@ async def _wait_for_close(
     a close event lands, so there is no client-side sleep or polling loop.
     """
     async with helper.client() as client:
-        return cast(
-            GetWorkflowExecutionHistoryResponse,
-            await client.workflow_stub.GetWorkflowExecutionHistory(
-                GetWorkflowExecutionHistoryRequest(
-                    domain=DOMAIN_NAME,
-                    workflow_execution=execution,
-                    wait_for_new_event=True,
-                    history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_CLOSE_EVENT,
-                    skip_archival=True,
-                )
-            ),
+        response: GetWorkflowExecutionHistoryResponse = await client.workflow_stub.GetWorkflowExecutionHistory(
+            GetWorkflowExecutionHistoryRequest(
+                domain=DOMAIN_NAME,
+                workflow_execution=execution,
+                wait_for_new_event=True,
+                history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_CLOSE_EVENT,
+                skip_archival=True,
+            )
         )
+        return response
 
 
 async def test_workflow_retries_on_failure(helper: CadenceHelper):


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
fix typesafety failure on retry test, also make ci to include test folder for type safety check

<!-- Tell your future self why have you made these changes -->
**Why?**
`make` command includes test folder for type safety check while github action does not. Causing us to miss this issue since online ci is passing.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**