### PR TITLE
chore(openai): propagate needs_approval field for tools

### DIFF
--- a/cadence/contrib/openai/cadence_tool.py
+++ b/cadence/contrib/openai/cadence_tool.py
@@ -16,6 +16,7 @@ class CadenceFunctionTool:
     params_json_schema: dict[str, Any]
     strict_json_schema: bool = True
     is_enabled: bool = True
+    needs_approval: bool = False
 
 
 """CadenceTool is a union of all the tool types that can be used with Cadence."""
@@ -33,6 +34,7 @@ def to_cadence_tool(tool: Tool) -> CadenceTool:
             params_json_schema=tool.params_json_schema,
             strict_json_schema=tool.strict_json_schema,
             is_enabled=tool.is_enabled,
+            needs_approval=tool.needs_approval,
         )
     raise ValueError(f"Unknown tool type: {type(tool)}")
 
@@ -49,6 +51,7 @@ def from_cadence_tool(tool: CadenceTool) -> Tool:
             params_json_schema=tool.params_json_schema,
             strict_json_schema=tool.strict_json_schema,
             is_enabled=tool.is_enabled,
+            needs_approval=tool.needs_approval,
             on_invoke_tool=noop_on_invoke_tool,
         )
     raise ValueError(f"Unknown tool type: {type(tool)}")

--- a/cadence/contrib/openai/cadence_tool.py
+++ b/cadence/contrib/openai/cadence_tool.py
@@ -28,6 +28,9 @@ def to_cadence_tool(tool: Tool) -> CadenceTool:
         if not isinstance(tool.is_enabled, bool):
             raise ValueError("is_enabled must be a bool")
 
+        if not isinstance(tool.needs_approval, bool):
+            raise ValueError("needs_approval must be a bool")
+
         return CadenceFunctionTool(
             name=tool.name,
             description=tool.description,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* in mappers between cadence tools and tools, propagate needs_approval

<!-- Tell your future self why have you made these changes -->
**Why?**

needed for tool guard

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**