### PR TITLE
feat(query): support default __query_types query

### DIFF
--- a/cadence/client.py
+++ b/cadence/client.py
@@ -447,7 +447,6 @@ class Client:
         *query_args: Any,
         result_type: type = object,
         query_reject_condition: QueryRejectCondition | None = None,
-        query_consistency_level: QueryConsistencyLevel | None = None,
     ) -> Any:
         """
         Query a running workflow execution's state.
@@ -462,7 +461,6 @@ class Client:
             *query_args: Arguments to pass to the query handler.
             result_type: The expected return type for deserialization.
             query_reject_condition: Optional condition to reject the query.
-            query_consistency_level: Optional consistency level for the query.
 
         Returns:
             The deserialized query result.
@@ -492,12 +490,11 @@ class Client:
             domain=self.domain,
             workflow_execution=workflow_execution,
             query=wf_query,
+            query_consistency_level=QueryConsistencyLevel.QUERY_CONSISTENCY_LEVEL_EVENTUAL,
         )
 
         if query_reject_condition is not None:
             request.query_reject_condition = query_reject_condition
-        if query_consistency_level is not None:
-            request.query_consistency_level = query_consistency_level
 
         response: QueryWorkflowResponse = await self.workflow_stub.QueryWorkflow(
             request

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from collections import OrderedDict
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -253,8 +252,11 @@ class WorkflowDefinition(Generic[C]):
         # declares a `self` parameter so it matches the calling convention
         # used by `WorkflowInstance.handle_query`; `FnSignature.of` filters
         # `self` out so it is not decoded from the query payload.
+        def _query_types_handler(self: Any) -> list[str]:
+            return sorted(list(queries.keys()))
+
         queries[_QUERY_TYPES_QUERY_NAME] = QueryDefinition.wrap(
-            lambda self: sorted(list(queries.keys())),
+            _query_types_handler,
             QueryDefinitionOptions(name=_QUERY_TYPES_QUERY_NAME),
         )
 

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -24,6 +25,8 @@ from cadence.data_converter import DataConverter
 from cadence.error import ContinueAsNewError
 from cadence.query import QueryDefinition, QueryDefinitionOptions
 from cadence.signal import SignalDefinition, SignalDefinitionOptions
+
+_QUERY_TYPES_QUERY_NAME = "__query_types"
 
 ResultType = TypeVar("ResultType")
 
@@ -244,6 +247,16 @@ class WorkflowDefinition(Generic[C]):
 
         if run_method_name is None or run_signature is None:
             raise ValueError(f"No @workflow.run method found in class {cls.__name__}")
+
+        # Register the built-in __query_types query, which returns the names
+        # of all registered query handlers (including itself). The handler
+        # declares a `self` parameter so it matches the calling convention
+        # used by `WorkflowInstance.handle_query`; `FnSignature.of` filters
+        # `self` out so it is not decoded from the query payload.
+        queries[_QUERY_TYPES_QUERY_NAME] = QueryDefinition.wrap(
+            lambda self: sorted(list(queries.keys())),
+            QueryDefinitionOptions(name=_QUERY_TYPES_QUERY_NAME),
+        )
 
         return WorkflowDefinition(
             cls, name, run_method_name, signals, queries, run_signature

--- a/tests/cadence/_internal/rpc/test_error.py
+++ b/tests/cadence/_internal/rpc/test_error.py
@@ -1,5 +1,5 @@
 from concurrent import futures
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from google.protobuf import any_pb2

--- a/tests/cadence/_internal/rpc/test_error.py
+++ b/tests/cadence/_internal/rpc/test_error.py
@@ -1,5 +1,5 @@
 from concurrent import futures
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from google.protobuf import any_pb2
@@ -198,4 +198,4 @@ def details_to_status(message: Message) -> Status:
         message="message",
         details=[detail],
     )
-    return to_status(status_proto)
+    return cast(Status, to_status(status_proto))

--- a/tests/cadence/_internal/rpc/test_error.py
+++ b/tests/cadence/_internal/rpc/test_error.py
@@ -198,4 +198,4 @@ def details_to_status(message: Message) -> Status:
         message="message",
         details=[detail],
     )
-    return cast(Status, to_status(status_proto))
+    return to_status(status_proto)

--- a/tests/cadence/_internal/workflow/test_query_handling.py
+++ b/tests/cadence/_internal/workflow/test_query_handling.py
@@ -470,7 +470,10 @@ class TestQueryDefinitionValidation:
         )
         assert "get_status" in workflow_def.queries
         assert "get_count" in workflow_def.queries
-        assert len(workflow_def.queries) == 2
+        # WorkflowDefinition automatically registers a built-in __query_types
+        # handler that reports the names of every registered query.
+        assert "__query_types" in workflow_def.queries
+        assert len(workflow_def.queries) == 3
 
     def test_workflow_definition_includes_both_signals_and_queries(self):
         """WorkflowDefinition correctly separates signals from queries."""
@@ -481,6 +484,41 @@ class TestQueryDefinitionValidation:
         assert "add_message" in workflow_def.signals
         assert "get_messages" in workflow_def.queries
         assert "get_message_count" in workflow_def.queries
+
+    def test_workflow_without_user_queries_still_has_query_types(self):
+        """A workflow that defines no query handlers still gets __query_types."""
+        workflow_def = WorkflowDefinition.wrap(
+            NoQueryWorkflow, WorkflowDefinitionOptions(name="NoQueryWorkflow")
+        )
+        assert set(workflow_def.queries) == {"__query_types"}
+
+
+class TestQueryTypesBuiltIn:
+    """Tests for the built-in __query_types query handler."""
+
+    def test_query_types_returns_all_registered_names(self):
+        """__query_types lists every registered query, including itself."""
+        engine = make_workflow_engine(QueryWorkflow)
+        events = start_events()
+        query = make_query("__query_types")
+
+        result = engine.process_decision(events, query)
+        assert result.query_result is not None
+        assert result.query_result.result_type == QUERY_RESULT_TYPE_ANSWERED
+        decoded = DATA_CONVERTER.from_data(result.query_result.answer, [list[str]])
+        assert set(decoded[0]) == {"get_status", "get_count", "__query_types"}
+
+    def test_query_types_for_workflow_with_no_user_queries(self):
+        """__query_types returns just itself when no user queries are defined."""
+        engine = make_workflow_engine(NoQueryWorkflow)
+        events = start_events()
+        query = make_query("__query_types")
+
+        result = engine.process_decision(events, query)
+        assert result.query_result is not None
+        assert result.query_result.result_type == QUERY_RESULT_TYPE_ANSWERED
+        decoded = DATA_CONVERTER.from_data(result.query_result.answer, [list[str]])
+        assert decoded[0] == ["__query_types"]
 
 
 class TestQueryHandlerException:

--- a/tests/integration_tests/workflow/test_query.py
+++ b/tests/integration_tests/workflow/test_query.py
@@ -392,6 +392,7 @@ async def test_multiple_query_handlers(helper: CadenceHelper):
         )
         await _wait_for_workflow_result(helper, execution)
 
+
 async def test_query_handler_raises_returns_query_failed_error(
     helper: CadenceHelper,
 ):

--- a/tests/integration_tests/workflow/test_query.py
+++ b/tests/integration_tests/workflow/test_query.py
@@ -335,6 +335,15 @@ async def test_multiple_query_handlers(helper: CadenceHelper):
             execution_start_to_close_timeout=timedelta(seconds=30),
         )
 
+        result = await worker.client.query_workflow(
+            execution.workflow_id,
+            execution.run_id,
+            "__query_types",
+            result_type=list[str],
+        )
+
+        assert result == ["__query_types", "get_count", "get_messages"]
+
         count = await _poll_query(
             helper,
             execution.workflow_id,
@@ -382,7 +391,6 @@ async def test_multiple_query_handlers(helper: CadenceHelper):
             "finish",
         )
         await _wait_for_workflow_result(helper, execution)
-
 
 async def test_query_handler_raises_returns_query_failed_error(
     helper: CadenceHelper,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* add __query_types query as default
* remove queryconsistencylevel from the API. All queries should be eventual consistent query. 

<!-- Tell your future self why have you made these changes -->
**Why?**

UI needs this to get all query handlers 
<img width="735" height="350" alt="Screenshot 2026-05-20 at 10 03 16 AM" src="https://github.com/user-attachments/assets/f95de7c2-0fbd-4dca-9179-734353112c88" />

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**