### PR TITLE
feat: add execute_child_workflow

### DIFF
--- a/cadence/_internal/workflow/context.py
+++ b/cadence/_internal/workflow/context.py
@@ -7,15 +7,18 @@ from typing import Iterator, Optional, Any, Unpack, Type, cast, Callable
 from cadence._internal.workflow.deterministic_event_loop import DeterministicEventLoop
 from cadence._internal.workflow.retry_policy import retry_policy_to_proto
 from cadence._internal.workflow.statemachine.decision_manager import DecisionManager
-from cadence.api.v1.common_pb2 import ActivityType
+from cadence.api.v1 import workflow_pb2
+from cadence.api.v1.common_pb2 import ActivityType, WorkflowType
 from cadence.api.v1.decision_pb2 import (
     ScheduleActivityTaskDecisionAttributes,
+    StartChildWorkflowExecutionDecisionAttributes,
     StartTimerDecisionAttributes,
 )
 from cadence.api.v1.tasklist_pb2 import TaskList, TaskListKind
 from cadence.data_converter import DataConverter
 from cadence.workflow import (
     ActivityOptions,
+    ChildWorkflowOptions,
     ResultType,
     WorkflowContext,
     WorkflowInfo,
@@ -103,6 +106,78 @@ class Context(WorkflowContext):
 
         result = self.data_converter().from_data(result_payload, [result_type])[0]
 
+        return cast(ResultType, result)
+
+    async def execute_child_workflow(
+        self,
+        workflow_type: str,
+        result_type: Type[ResultType],
+        *args: Any,
+        **kwargs: Unpack[ChildWorkflowOptions],
+    ) -> ResultType:
+        execution_timeout = kwargs.get("execution_start_to_close_timeout")
+        if execution_timeout is None:
+            raise ValueError(
+                "execution_start_to_close_timeout is required for child workflow execution"
+            )
+        if execution_timeout <= timedelta(0):
+            raise ValueError("execution_start_to_close_timeout must be greater than 0")
+
+        task_timeout = kwargs.get("task_start_to_close_timeout", timedelta(seconds=10))
+        if task_timeout <= timedelta(0):
+            raise ValueError("task_start_to_close_timeout must be greater than 0")
+
+        domain = kwargs.get("domain") or self._info.workflow_domain
+        task_list = kwargs.get("task_list") or self._info.workflow_task_list
+
+        workflow_id = kwargs.get("workflow_id")
+        if not workflow_id:
+            workflow_id = (
+                f"{self._info.workflow_run_id}_{self._decision_manager._next_id()}"
+            )
+
+        parent_close_policy = kwargs.get(
+            "parent_close_policy",
+            workflow_pb2.PARENT_CLOSE_POLICY_TERMINATE,
+        )
+        workflow_id_reuse_policy = kwargs.get(
+            "workflow_id_reuse_policy",
+            workflow_pb2.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+        )
+        if (
+            workflow_id_reuse_policy
+            == workflow_pb2.WORKFLOW_ID_REUSE_POLICY_INVALID
+        ):
+            raise ValueError(
+                "workflow_id_reuse_policy cannot be WORKFLOW_ID_REUSE_POLICY_INVALID"
+            )
+
+        child_input = self.data_converter().to_data(list(args))
+        schedule_attributes = StartChildWorkflowExecutionDecisionAttributes(
+            domain=domain,
+            workflow_id=workflow_id,
+            workflow_type=WorkflowType(name=workflow_type),
+            task_list=TaskList(kind=TaskListKind.TASK_LIST_KIND_NORMAL, name=task_list),
+            input=child_input,
+            execution_start_to_close_timeout=_round_to_nearest_second(
+                execution_timeout
+            ),
+            task_start_to_close_timeout=_round_to_nearest_second(task_timeout),
+            parent_close_policy=parent_close_policy,
+            workflow_id_reuse_policy=workflow_id_reuse_policy,
+            retry_policy=retry_policy_to_proto(kwargs.get("retry_policy")),
+        )
+
+        cron_schedule = kwargs.get("cron_schedule")
+        if cron_schedule:
+            schedule_attributes.cron_schedule = cron_schedule
+
+        _execution_future, result_future = (
+            self._decision_manager.schedule_child_workflow(schedule_attributes)
+        )
+
+        result_payload = await result_future
+        result = self.data_converter().from_data(result_payload, [result_type])[0]
         return cast(ResultType, result)
 
     async def start_timer(self, duration: timedelta):

--- a/cadence/_internal/workflow/context.py
+++ b/cadence/_internal/workflow/context.py
@@ -144,10 +144,7 @@ class Context(WorkflowContext):
             "workflow_id_reuse_policy",
             workflow_pb2.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
         )
-        if (
-            workflow_id_reuse_policy
-            == workflow_pb2.WORKFLOW_ID_REUSE_POLICY_INVALID
-        ):
+        if workflow_id_reuse_policy == workflow_pb2.WORKFLOW_ID_REUSE_POLICY_INVALID:
             raise ValueError(
                 "workflow_id_reuse_policy cannot be WORKFLOW_ID_REUSE_POLICY_INVALID"
             )

--- a/cadence/_internal/workflow/context.py
+++ b/cadence/_internal/workflow/context.py
@@ -130,11 +130,7 @@ class Context(WorkflowContext):
         domain = kwargs.get("domain") or self._info.workflow_domain
         task_list = kwargs.get("task_list") or self._info.workflow_task_list
 
-        workflow_id = kwargs.get("workflow_id")
-        if not workflow_id:
-            workflow_id = (
-                f"{self._info.workflow_run_id}_{self._decision_manager._next_id()}"
-            )
+        workflow_id = kwargs.get("workflow_id") or ""
 
         parent_close_policy = kwargs.get(
             "parent_close_policy",
@@ -170,7 +166,10 @@ class Context(WorkflowContext):
             schedule_attributes.cron_schedule = cron_schedule
 
         _execution_future, result_future = (
-            self._decision_manager.schedule_child_workflow(schedule_attributes)
+            self._decision_manager.schedule_child_workflow(
+                schedule_attributes,
+                parent_workflow_run_id=self._info.workflow_run_id,
+            )
         )
 
         result_payload = await result_future

--- a/cadence/_internal/workflow/statemachine/decision_manager.py
+++ b/cadence/_internal/workflow/statemachine/decision_manager.py
@@ -2,7 +2,7 @@ import asyncio
 from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Dict, Type, Tuple, ClassVar, List, Iterator
+from typing import Any, Dict, Type, ClassVar, List, Iterator
 
 from cadence._internal.workflow.statemachine.activity_state_machine import (
     activity_events,
@@ -35,7 +35,12 @@ from cadence._internal.workflow.statemachine.timer_state_machine import (
 from cadence.api.v1 import decision, history
 from cadence.api.v1.common_pb2 import Payload, WorkflowExecution
 
-DecisionAlias = Tuple[DecisionType, str | int]
+DecisionAlias = tuple[DecisionType, str | int]
+
+
+def _consume_future_exception(future: asyncio.Future[Any]) -> None:
+    if not future.cancelled():
+        future.exception()
 
 
 @dataclass(frozen=True)
@@ -118,14 +123,19 @@ class DecisionManager:
 
     # ----- Child Workflow API -----
     def schedule_child_workflow(
-        self, attrs: decision.StartChildWorkflowExecutionDecisionAttributes
-    ) -> tuple[asyncio.Future[WorkflowExecution], asyncio.Future[Payload]]:
+        self,
+        attrs: decision.StartChildWorkflowExecutionDecisionAttributes,
+        *,
+        parent_workflow_run_id: str,
+    ) -> tuple[DecisionFuture[WorkflowExecution], DecisionFuture[Payload]]:
+
+        if not attrs.workflow_id:
+            attrs.workflow_id = f"{parent_workflow_run_id}_{self._next_id()}"
         if self._replaying:
             self._determinism_tracker.validate_action(attrs)
         decision_id = DecisionId(DecisionType.CHILD_WORKFLOW, attrs.workflow_id)
         execution: DecisionFuture[WorkflowExecution] = self._create_future(decision_id)
-        # Child workflows have two milestones: started execution and terminal result.
-        # The result future is also the cancellation handle after the child starts.
+        execution.add_done_callback(_consume_future_exception)
         result: DecisionFuture[Payload] = DecisionFuture(
             self._event_loop, lambda: self._request_cancel(decision_id)
         )

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -20,6 +20,7 @@ from typing import (
 import inspect
 
 from cadence._internal.fn_signature import FnSignature
+from cadence.api.v1 import workflow_pb2
 from cadence.data_converter import DataConverter
 from cadence.error import ContinueAsNewError
 from cadence.query import QueryDefinition, QueryDefinitionOptions
@@ -63,8 +64,8 @@ class ChildWorkflowOptions(TypedDict, total=False):
     task_list: str
     execution_start_to_close_timeout: timedelta
     task_start_to_close_timeout: timedelta
-    parent_close_policy: int
-    workflow_id_reuse_policy: int
+    parent_close_policy: Union[workflow_pb2.ParentClosePolicy, str]
+    workflow_id_reuse_policy: Union[workflow_pb2.WorkflowIdReusePolicy, str]
     retry_policy: RetryPolicy
     cron_schedule: str
 

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -57,6 +57,18 @@ class ActivityOptions(TypedDict, total=False):
     retry_policy: RetryPolicy
 
 
+class ChildWorkflowOptions(TypedDict, total=False):
+    workflow_id: str
+    domain: str
+    task_list: str
+    execution_start_to_close_timeout: timedelta
+    task_start_to_close_timeout: timedelta
+    parent_close_policy: int
+    workflow_id_reuse_policy: int
+    retry_policy: RetryPolicy
+    cron_schedule: str
+
+
 async def execute_activity(
     activity: str,
     result_type: Type[ResultType],
@@ -65,6 +77,17 @@ async def execute_activity(
 ) -> ResultType:
     return await WorkflowContext.get().execute_activity(
         activity, result_type, *args, **kwargs
+    )
+
+
+async def execute_child_workflow(
+    workflow_type: str,
+    result_type: Type[ResultType],
+    *args: Any,
+    **kwargs: Unpack[ChildWorkflowOptions],
+) -> ResultType:
+    return await WorkflowContext.get().execute_child_workflow(
+        workflow_type, result_type, *args, **kwargs
     )
 
 
@@ -447,6 +470,15 @@ class WorkflowContext(ABC):
         result_type: Type[ResultType],
         *args: Any,
         **kwargs: Unpack[ActivityOptions],
+    ) -> ResultType: ...
+
+    @abstractmethod
+    async def execute_child_workflow(
+        self,
+        workflow_type: str,
+        result_type: Type[ResultType],
+        *args: Any,
+        **kwargs: Unpack[ChildWorkflowOptions],
     ) -> ResultType: ...
 
     @abstractmethod

--- a/tests/cadence/_internal/workflow/statemachine/test_decision_manager.py
+++ b/tests/cadence/_internal/workflow/statemachine/test_decision_manager.py
@@ -176,7 +176,8 @@ async def test_child_workflow_dispatch():
         decision.StartChildWorkflowExecutionDecisionAttributes(
             workflow_id="child-wf-1",
             workflow_type=WorkflowType(name="MyWorkflow"),
-        )
+        ),
+        parent_workflow_run_id="parent-run",
     )
 
     decisions.handle_history_event(child_wf_initiated(1, "child-wf-1"))
@@ -195,6 +196,30 @@ async def test_child_workflow_dispatch():
     assert result.result() == Payload(data=b"done")
 
 
+async def test_schedule_child_workflow_generates_workflow_id():
+    decisions = DecisionManager(asyncio.get_event_loop())
+
+    attrs = decision.StartChildWorkflowExecutionDecisionAttributes(
+        workflow_id="",
+        workflow_type=WorkflowType(name="MyWorkflow"),
+    )
+    _execution, result = decisions.schedule_child_workflow(
+        attrs, parent_workflow_run_id="parent-run-xyz"
+    )
+
+    assert attrs.workflow_id == "parent-run-xyz_0"
+
+    decisions.handle_history_event(child_wf_initiated(1, attrs.workflow_id))
+    decisions.handle_history_event(
+        child_wf_started(2, started_event_id=1, wf_id=attrs.workflow_id, run_id="run-1")
+    )
+    decisions.handle_history_event(
+        child_wf_completed(3, started_event_id=1, result=Payload(data=b"done"))
+    )
+
+    assert result.result() == Payload(data=b"done")
+
+
 async def test_child_workflow_initiation_failed_dispatch():
     decisions = DecisionManager(asyncio.get_event_loop())
 
@@ -202,7 +227,8 @@ async def test_child_workflow_initiation_failed_dispatch():
         decision.StartChildWorkflowExecutionDecisionAttributes(
             workflow_id="child-wf-1",
             workflow_type=WorkflowType(name="MyWorkflow"),
-        )
+        ),
+        parent_workflow_run_id="parent-run",
     )
 
     decisions.handle_history_event(child_wf_initiated(1, "child-wf-1"))
@@ -226,11 +252,12 @@ async def test_child_workflow_initiation_failed_dispatch():
 async def test_child_workflow_cancel_dispatch():
     decisions = DecisionManager(asyncio.get_event_loop())
 
-    execution, result = decisions.schedule_child_workflow(
+    _execution, result = decisions.schedule_child_workflow(
         decision.StartChildWorkflowExecutionDecisionAttributes(
             workflow_id="child-wf-1",
             workflow_type=WorkflowType(name="MyWorkflow"),
-        )
+        ),
+        parent_workflow_run_id="parent-run",
     )
 
     decisions.handle_history_event(child_wf_initiated(1, "child-wf-1"))
@@ -269,11 +296,12 @@ async def test_child_workflow_errors_are_child_workflow_error():
     """All child workflow errors share a common base class."""
     decisions = DecisionManager(asyncio.get_event_loop())
 
-    _, result = decisions.schedule_child_workflow(
+    _execution, result = decisions.schedule_child_workflow(
         decision.StartChildWorkflowExecutionDecisionAttributes(
             workflow_id="child-wf-1",
             workflow_type=WorkflowType(name="MyWorkflow"),
-        )
+        ),
+        parent_workflow_run_id="parent-run",
     )
 
     decisions.handle_history_event(child_wf_initiated(1, "child-wf-1"))

--- a/tests/cadence/_internal/workflow/test_context_child_workflow.py
+++ b/tests/cadence/_internal/workflow/test_context_child_workflow.py
@@ -33,7 +33,9 @@ def _make_ctx(run_id: str = "rid") -> tuple[Context, MagicMock]:
 
 
 def _setup_schedule_mock(
-    dm: MagicMock, result_value: object = "result", loop: asyncio.AbstractEventLoop | None = None
+    dm: MagicMock,
+    result_value: object = "result",
+    loop: asyncio.AbstractEventLoop | None = None,
 ) -> None:
     dc = DefaultDataConverter()
     loop = loop or asyncio.get_event_loop()
@@ -130,7 +132,9 @@ async def test_execute_child_workflow_uses_provided_workflow_id():
 async def test_execute_child_workflow_raises_without_execution_timeout():
     ctx, dm = _make_ctx()
 
-    with pytest.raises(ValueError, match="execution_start_to_close_timeout is required"):
+    with pytest.raises(
+        ValueError, match="execution_start_to_close_timeout is required"
+    ):
         await ctx.execute_child_workflow("ChildWf", str)
 
 

--- a/tests/cadence/_internal/workflow/test_context_child_workflow.py
+++ b/tests/cadence/_internal/workflow/test_context_child_workflow.py
@@ -1,0 +1,310 @@
+import asyncio
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from google.protobuf.duration_pb2 import Duration
+
+from cadence._internal.workflow.context import Context
+from cadence._internal.workflow.statemachine.child_workflow_execution_state_machine import (
+    ChildWorkflowExecutionFailed,
+)
+from cadence.api.v1 import workflow_pb2
+from cadence.api.v1.common_pb2 import WorkflowType
+from cadence.api.v1.decision_pb2 import StartChildWorkflowExecutionDecisionAttributes
+from cadence.api.v1.tasklist_pb2 import TaskList, TaskListKind
+from cadence.data_converter import DefaultDataConverter
+from cadence.workflow import WorkflowInfo
+
+
+def _make_ctx(run_id: str = "rid") -> tuple[Context, MagicMock]:
+    dm = MagicMock()
+    dc = DefaultDataConverter()
+    info = WorkflowInfo(
+        workflow_type="ParentWf",
+        workflow_domain="domain",
+        workflow_id="wid",
+        workflow_run_id=run_id,
+        workflow_task_list="tl",
+        data_converter=dc,
+    )
+    ctx = Context(info, dm)
+    return ctx, dm
+
+
+def _setup_schedule_mock(
+    dm: MagicMock, result_value: object = "result", loop: asyncio.AbstractEventLoop | None = None
+) -> None:
+    dc = DefaultDataConverter()
+    loop = loop or asyncio.get_event_loop()
+    execution_future: asyncio.Future = loop.create_future()
+    execution_future.set_result(None)
+    result_future: asyncio.Future = loop.create_future()
+    result_future.set_result(dc.to_data([result_value]))
+    dm.schedule_child_workflow = MagicMock(
+        return_value=(execution_future, result_future)
+    )
+
+
+def _setup_schedule_mock_error(
+    dm: MagicMock, error: Exception, loop: asyncio.AbstractEventLoop | None = None
+) -> None:
+    loop = loop or asyncio.get_event_loop()
+    execution_future: asyncio.Future = loop.create_future()
+    execution_future.set_result(None)
+    result_future: asyncio.Future = loop.create_future()
+    result_future.set_exception(error)
+    dm.schedule_child_workflow = MagicMock(
+        return_value=(execution_future, result_future)
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_child_workflow_basic():
+    ctx, dm = _make_ctx()
+    _setup_schedule_mock(dm)
+    dm._next_id = MagicMock(return_value="0")
+
+    result = await ctx.execute_child_workflow(
+        "ChildWf",
+        str,
+        "arg1",
+        "arg2",
+        execution_start_to_close_timeout=timedelta(minutes=10),
+    )
+
+    dm.schedule_child_workflow.assert_called_once()
+    attrs: StartChildWorkflowExecutionDecisionAttributes = (
+        dm.schedule_child_workflow.call_args[0][0]
+    )
+    assert attrs.workflow_type == WorkflowType(name="ChildWf")
+    assert attrs.domain == "domain"
+    assert attrs.task_list == TaskList(
+        kind=TaskListKind.TASK_LIST_KIND_NORMAL, name="tl"
+    )
+    assert attrs.execution_start_to_close_timeout == Duration(seconds=600)
+    assert attrs.task_start_to_close_timeout == Duration(seconds=10)
+    assert result == "result"
+
+
+@pytest.mark.asyncio
+async def test_execute_child_workflow_auto_generates_workflow_id():
+    ctx, dm = _make_ctx(run_id="test-run-id")
+    _setup_schedule_mock(dm)
+    dm._next_id = MagicMock(return_value="42")
+
+    await ctx.execute_child_workflow(
+        "ChildWf",
+        str,
+        execution_start_to_close_timeout=timedelta(minutes=5),
+    )
+
+    attrs: StartChildWorkflowExecutionDecisionAttributes = (
+        dm.schedule_child_workflow.call_args[0][0]
+    )
+    assert attrs.workflow_id == "test-run-id_42"
+    dm._next_id.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_child_workflow_uses_provided_workflow_id():
+    ctx, dm = _make_ctx()
+    _setup_schedule_mock(dm)
+    dm._next_id = MagicMock(return_value="0")
+
+    await ctx.execute_child_workflow(
+        "ChildWf",
+        str,
+        workflow_id="my-child-1",
+        execution_start_to_close_timeout=timedelta(minutes=5),
+    )
+
+    attrs: StartChildWorkflowExecutionDecisionAttributes = (
+        dm.schedule_child_workflow.call_args[0][0]
+    )
+    assert attrs.workflow_id == "my-child-1"
+    dm._next_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_child_workflow_raises_without_execution_timeout():
+    ctx, dm = _make_ctx()
+
+    with pytest.raises(ValueError, match="execution_start_to_close_timeout is required"):
+        await ctx.execute_child_workflow("ChildWf", str)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timeout", [timedelta(0), timedelta(seconds=-1)])
+async def test_execute_child_workflow_raises_for_invalid_execution_timeout(
+    timeout: timedelta,
+):
+    ctx, dm = _make_ctx()
+
+    with pytest.raises(
+        ValueError, match="execution_start_to_close_timeout must be greater than 0"
+    ):
+        await ctx.execute_child_workflow(
+            "ChildWf",
+            str,
+            execution_start_to_close_timeout=timeout,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timeout", [timedelta(0), timedelta(seconds=-1)])
+async def test_execute_child_workflow_raises_for_invalid_task_timeout(
+    timeout: timedelta,
+):
+    ctx, dm = _make_ctx()
+
+    with pytest.raises(
+        ValueError, match="task_start_to_close_timeout must be greater than 0"
+    ):
+        await ctx.execute_child_workflow(
+            "ChildWf",
+            str,
+            execution_start_to_close_timeout=timedelta(minutes=5),
+            task_start_to_close_timeout=timeout,
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_child_workflow_raises_for_invalid_workflow_id_reuse_policy():
+    ctx, dm = _make_ctx()
+
+    with pytest.raises(
+        ValueError,
+        match="workflow_id_reuse_policy cannot be WORKFLOW_ID_REUSE_POLICY_INVALID",
+    ):
+        await ctx.execute_child_workflow(
+            "ChildWf",
+            str,
+            execution_start_to_close_timeout=timedelta(minutes=5),
+            workflow_id_reuse_policy=workflow_pb2.WORKFLOW_ID_REUSE_POLICY_INVALID,
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_child_workflow_default_values():
+    ctx, dm = _make_ctx()
+    _setup_schedule_mock(dm)
+    dm._next_id = MagicMock(return_value="0")
+
+    await ctx.execute_child_workflow(
+        "ChildWf",
+        str,
+        execution_start_to_close_timeout=timedelta(minutes=5),
+    )
+
+    attrs: StartChildWorkflowExecutionDecisionAttributes = (
+        dm.schedule_child_workflow.call_args[0][0]
+    )
+    assert attrs.task_start_to_close_timeout == Duration(seconds=10)
+    assert attrs.parent_close_policy == workflow_pb2.PARENT_CLOSE_POLICY_TERMINATE
+    assert (
+        attrs.workflow_id_reuse_policy
+        == workflow_pb2.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_child_workflow_custom_options():
+    ctx, dm = _make_ctx()
+    _setup_schedule_mock(dm)
+    dm._next_id = MagicMock(return_value="0")
+
+    await ctx.execute_child_workflow(
+        "ChildWf",
+        str,
+        execution_start_to_close_timeout=timedelta(minutes=5),
+        parent_close_policy=workflow_pb2.PARENT_CLOSE_POLICY_ABANDON,
+        domain="other-domain",
+        task_list="other-tl",
+    )
+
+    attrs: StartChildWorkflowExecutionDecisionAttributes = (
+        dm.schedule_child_workflow.call_args[0][0]
+    )
+    assert attrs.parent_close_policy == workflow_pb2.PARENT_CLOSE_POLICY_ABANDON
+    assert attrs.domain == "other-domain"
+    assert attrs.task_list == TaskList(
+        kind=TaskListKind.TASK_LIST_KIND_NORMAL, name="other-tl"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_child_workflow_retry_policy():
+    ctx, dm = _make_ctx()
+    _setup_schedule_mock(dm)
+    dm._next_id = MagicMock(return_value="0")
+
+    await ctx.execute_child_workflow(
+        "ChildWf",
+        str,
+        execution_start_to_close_timeout=timedelta(minutes=5),
+        retry_policy={
+            "initial_interval": timedelta(seconds=2),
+            "backoff_coefficient": 2.0,
+            "maximum_attempts": 3,
+        },
+    )
+
+    attrs: StartChildWorkflowExecutionDecisionAttributes = (
+        dm.schedule_child_workflow.call_args[0][0]
+    )
+    rp = attrs.retry_policy
+    assert rp is not None
+    assert rp.initial_interval == Duration(seconds=2)
+    assert rp.backoff_coefficient == 2.0
+    assert rp.maximum_attempts == 3
+
+
+@pytest.mark.asyncio
+async def test_execute_child_workflow_deserializes_result():
+    ctx, dm = _make_ctx()
+    _setup_schedule_mock(dm, result_value=42)
+    dm._next_id = MagicMock(return_value="0")
+
+    result = await ctx.execute_child_workflow(
+        "ChildWf",
+        int,
+        execution_start_to_close_timeout=timedelta(minutes=5),
+    )
+
+    assert result == 42
+    assert isinstance(result, int)
+
+
+@pytest.mark.asyncio
+async def test_execute_child_workflow_propagates_errors():
+    ctx, dm = _make_ctx()
+    failure = ChildWorkflowExecutionFailed("child failed", failure=None)
+    _setup_schedule_mock_error(dm, failure)
+    dm._next_id = MagicMock(return_value="0")
+
+    with pytest.raises(ChildWorkflowExecutionFailed, match="child failed"):
+        await ctx.execute_child_workflow(
+            "ChildWf",
+            str,
+            execution_start_to_close_timeout=timedelta(minutes=5),
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_child_workflow_cron_schedule():
+    ctx, dm = _make_ctx()
+    _setup_schedule_mock(dm)
+    dm._next_id = MagicMock(return_value="0")
+
+    await ctx.execute_child_workflow(
+        "ChildWf",
+        str,
+        execution_start_to_close_timeout=timedelta(minutes=5),
+        cron_schedule="* * * * *",
+    )
+
+    attrs: StartChildWorkflowExecutionDecisionAttributes = (
+        dm.schedule_child_workflow.call_args[0][0]
+    )
+    assert attrs.cron_schedule == "* * * * *"

--- a/tests/cadence/_internal/workflow/test_context_child_workflow.py
+++ b/tests/cadence/_internal/workflow/test_context_child_workflow.py
@@ -65,7 +65,6 @@ def _setup_schedule_mock_error(
 async def test_execute_child_workflow_basic():
     ctx, dm = _make_ctx()
     _setup_schedule_mock(dm)
-    dm._next_id = MagicMock(return_value="0")
 
     result = await ctx.execute_child_workflow(
         "ChildWf",
@@ -93,7 +92,6 @@ async def test_execute_child_workflow_basic():
 async def test_execute_child_workflow_auto_generates_workflow_id():
     ctx, dm = _make_ctx(run_id="test-run-id")
     _setup_schedule_mock(dm)
-    dm._next_id = MagicMock(return_value="42")
 
     await ctx.execute_child_workflow(
         "ChildWf",
@@ -104,15 +102,16 @@ async def test_execute_child_workflow_auto_generates_workflow_id():
     attrs: StartChildWorkflowExecutionDecisionAttributes = (
         dm.schedule_child_workflow.call_args[0][0]
     )
-    assert attrs.workflow_id == "test-run-id_42"
-    dm._next_id.assert_called_once()
+    assert attrs.workflow_id == ""
+    assert dm.schedule_child_workflow.call_args.kwargs["parent_workflow_run_id"] == (
+        "test-run-id"
+    )
 
 
 @pytest.mark.asyncio
 async def test_execute_child_workflow_uses_provided_workflow_id():
     ctx, dm = _make_ctx()
     _setup_schedule_mock(dm)
-    dm._next_id = MagicMock(return_value="0")
 
     await ctx.execute_child_workflow(
         "ChildWf",
@@ -125,7 +124,6 @@ async def test_execute_child_workflow_uses_provided_workflow_id():
         dm.schedule_child_workflow.call_args[0][0]
     )
     assert attrs.workflow_id == "my-child-1"
-    dm._next_id.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -193,7 +191,6 @@ async def test_execute_child_workflow_raises_for_invalid_workflow_id_reuse_polic
 async def test_execute_child_workflow_default_values():
     ctx, dm = _make_ctx()
     _setup_schedule_mock(dm)
-    dm._next_id = MagicMock(return_value="0")
 
     await ctx.execute_child_workflow(
         "ChildWf",
@@ -216,7 +213,6 @@ async def test_execute_child_workflow_default_values():
 async def test_execute_child_workflow_custom_options():
     ctx, dm = _make_ctx()
     _setup_schedule_mock(dm)
-    dm._next_id = MagicMock(return_value="0")
 
     await ctx.execute_child_workflow(
         "ChildWf",
@@ -241,7 +237,6 @@ async def test_execute_child_workflow_custom_options():
 async def test_execute_child_workflow_retry_policy():
     ctx, dm = _make_ctx()
     _setup_schedule_mock(dm)
-    dm._next_id = MagicMock(return_value="0")
 
     await ctx.execute_child_workflow(
         "ChildWf",
@@ -268,7 +263,6 @@ async def test_execute_child_workflow_retry_policy():
 async def test_execute_child_workflow_deserializes_result():
     ctx, dm = _make_ctx()
     _setup_schedule_mock(dm, result_value=42)
-    dm._next_id = MagicMock(return_value="0")
 
     result = await ctx.execute_child_workflow(
         "ChildWf",
@@ -285,7 +279,6 @@ async def test_execute_child_workflow_propagates_errors():
     ctx, dm = _make_ctx()
     failure = ChildWorkflowExecutionFailed("child failed", failure=None)
     _setup_schedule_mock_error(dm, failure)
-    dm._next_id = MagicMock(return_value="0")
 
     with pytest.raises(ChildWorkflowExecutionFailed, match="child failed"):
         await ctx.execute_child_workflow(
@@ -299,7 +292,6 @@ async def test_execute_child_workflow_propagates_errors():
 async def test_execute_child_workflow_cron_schedule():
     ctx, dm = _make_ctx()
     _setup_schedule_mock(dm)
-    dm._next_id = MagicMock(return_value="0")
 
     await ctx.execute_child_workflow(
         "ChildWf",

--- a/tests/integration_tests/workflow/test_child_workflow.py
+++ b/tests/integration_tests/workflow/test_child_workflow.py
@@ -1,0 +1,63 @@
+from datetime import timedelta
+
+
+from cadence import Registry, workflow
+from cadence.api.v1.history_pb2 import EventFilterType
+from cadence.api.v1.service_workflow_pb2 import (
+    GetWorkflowExecutionHistoryRequest,
+    GetWorkflowExecutionHistoryResponse,
+)
+from cadence.workflow import WorkflowContext
+from tests.integration_tests.helper import CadenceHelper, DOMAIN_NAME
+
+reg = Registry()
+
+
+@reg.workflow()
+class ChildEchoWorkflow:
+    @workflow.run
+    async def run(self, message: str) -> str:
+        return f"child:{message}"
+
+
+@reg.workflow()
+class ParentRunsChildWorkflow:
+    @workflow.run
+    async def run(self, message: str) -> str:
+        run_id = WorkflowContext.get().info().workflow_run_id
+        child_workflow_id = f"{run_id}-child-echo"
+        return await workflow.execute_child_workflow(
+            "ChildEchoWorkflow",
+            str,
+            message,
+            workflow_id=child_workflow_id,
+            execution_start_to_close_timeout=timedelta(seconds=30),
+            task_start_to_close_timeout=timedelta(seconds=10),
+        )
+
+
+async def test_execute_child_workflow_end_to_end(helper: CadenceHelper):
+    async with helper.worker(reg) as worker:
+        execution = await worker.client.start_workflow(
+            "ParentRunsChildWorkflow",
+            "hello world",
+            task_list=worker.task_list,
+            execution_start_to_close_timeout=timedelta(seconds=30),
+        )
+
+        response: GetWorkflowExecutionHistoryResponse = await worker.client.workflow_stub.GetWorkflowExecutionHistory(
+            GetWorkflowExecutionHistoryRequest(
+                domain=DOMAIN_NAME,
+                workflow_execution=execution,
+                wait_for_new_event=True,
+                history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_CLOSE_EVENT,
+                skip_archival=True,
+            )
+        )
+
+        assert (
+            '"child:hello world"'
+            == response.history.events[
+                -1
+            ].workflow_execution_completed_event_attributes.result.data.decode()
+        )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add StartChildWorkflowOptions and execute_child_workflow (This will block the thread until child wf completes)

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**