### PR TITLE
fix: skip schedules test that is not working as expected

### DIFF
--- a/tests/integration_tests/test_schedule.py
+++ b/tests/integration_tests/test_schedule.py
@@ -97,6 +97,9 @@ async def test_create_describe_delete(helper: CadenceHelper):
 
 
 @pytest.mark.usefixtures("helper")
+@pytest.mark.skip(
+    reason="skip this test because it is not working as expected, see https://github.com/cadence-workflow/cadence-python-client/issues/117"
+)
 async def test_pause_and_unpause(helper: CadenceHelper):
     """Pause a schedule and verify state.paused, then unpause and verify cleared."""
     schedule_id = f"test-schedule-pause-{uuid.uuid4()}"
@@ -121,6 +124,9 @@ async def test_pause_and_unpause(helper: CadenceHelper):
 
 
 @pytest.mark.usefixtures("helper")
+@pytest.mark.skip(
+    reason="skip this test because it is not working as expected, see https://github.com/cadence-workflow/cadence-python-client/issues/117"
+)
 async def test_update_spec(helper: CadenceHelper):
     """Update a schedule's cron expression and verify describe reflects the change."""
     schedule_id = f"test-schedule-update-{uuid.uuid4()}"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Schedules tests are not working as intended, see issue: https://github.com/cadence-workflow/cadence-python-client/issues/117

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**