### PR TITLE
feat: incorporate SignalExternalWorkflowStateMachine into DecisionManager

### DIFF
--- a/cadence/_internal/workflow/statemachine/decision_manager.py
+++ b/cadence/_internal/workflow/statemachine/decision_manager.py
@@ -30,6 +30,7 @@ from cadence._internal.workflow.statemachine.event_dispatcher import (
 from cadence._internal.workflow.statemachine.nondeterminism import DeterminismTracker
 from cadence._internal.workflow.statemachine.signal_external_workflow_state_machine import (
     signal_external_events,
+    SignalExternalWorkflowStateMachine,
 )
 from cadence._internal.workflow.statemachine.timer_state_machine import (
     TimerStateMachine,
@@ -146,6 +147,22 @@ class DecisionManager:
         machine = ChildWorkflowExecutionStateMachine(attrs, execution, result)
         self._add_state_machine(machine)
         return execution, result
+
+    # ----- Signal External Workflow API -----
+
+    def signal_external_workflow(
+        self,
+        attrs: decision.SignalExternalWorkflowExecutionDecisionAttributes,
+    ) -> asyncio.Future[None]:
+        signal_id = self._next_id()
+        attrs.control = signal_id.encode("utf-8")
+        if self._replaying:
+            self._determinism_tracker.validate_action(attrs)
+        decision_id = DecisionId(DecisionType.SIGNAL, signal_id)
+        future: DecisionFuture[None] = self._create_future(decision_id)
+        machine = SignalExternalWorkflowStateMachine(attrs, future, signal_id)
+        self._add_state_machine(machine)
+        return future
 
     # ----- Workflow API -----
     def complete_workflow(self, decision: decision.Decision) -> None:

--- a/cadence/_internal/workflow/statemachine/nondeterminism.py
+++ b/cadence/_internal/workflow/statemachine/nondeterminism.py
@@ -344,6 +344,17 @@ def _(
     )
 
 
+@to_expectation.register
+def _(
+    attrs: history.SignalExternalWorkflowExecutionFailedEventAttributes,
+) -> Expectation:
+    # signal_name is not present in failed attrs; control still identifies the decision
+    return Expectation(
+        DecisionId(DecisionType.SIGNAL, attrs.control.decode("utf-8")),
+        {},
+    )
+
+
 # Workflow Completion - Enforce complete vs failure. Maybe we should enforce the output data?
 @to_expectation.register
 def _(_: decision.CompleteWorkflowExecutionDecisionAttributes) -> Expectation:

--- a/cadence/_internal/workflow/statemachine/nondeterminism.py
+++ b/cadence/_internal/workflow/statemachine/nondeterminism.py
@@ -323,6 +323,27 @@ def _(
     )
 
 
+# Signal External Workflow - Enforce signal_name
+@to_expectation.register
+def _(
+    attrs: decision.SignalExternalWorkflowExecutionDecisionAttributes,
+) -> Expectation:
+    return Expectation(
+        DecisionId(DecisionType.SIGNAL, attrs.control.decode("utf-8")),
+        {"signal_name": attrs.signal_name},
+    )
+
+
+@to_expectation.register
+def _(
+    attrs: history.SignalExternalWorkflowExecutionInitiatedEventAttributes,
+) -> Expectation:
+    return Expectation(
+        DecisionId(DecisionType.SIGNAL, attrs.control.decode("utf-8")),
+        {"signal_name": attrs.signal_name},
+    )
+
+
 # Workflow Completion - Enforce complete vs failure. Maybe we should enforce the output data?
 @to_expectation.register
 def _(_: decision.CompleteWorkflowExecutionDecisionAttributes) -> Expectation:

--- a/tests/cadence/_internal/workflow/statemachine/test_decision_manager.py
+++ b/tests/cadence/_internal/workflow/statemachine/test_decision_manager.py
@@ -12,6 +12,9 @@ from cadence._internal.workflow.statemachine.event_dispatcher import (
     EventDispatcher,
     resolve_id_attr,
 )
+from cadence._internal.workflow.statemachine.signal_external_workflow_state_machine import (
+    SignalExternalWorkflowFailed,
+)
 from cadence.api.v1 import history, decision
 from cadence.api.v1.common_pb2 import Payload, WorkflowExecution, WorkflowType
 
@@ -398,5 +401,138 @@ def activity_completed(
         event_id=event_id,
         activity_task_completed_event_attributes=history.ActivityTaskCompletedEventAttributes(
             scheduled_event_id=scheduled_id, result=result
+        ),
+    )
+
+
+async def test_signal_external_workflow_creates_machine():
+    decisions = DecisionManager(asyncio.get_event_loop())
+
+    future = decisions.signal_external_workflow(
+        decision.SignalExternalWorkflowExecutionDecisionAttributes(
+            domain="test-domain",
+            workflow_execution=WorkflowExecution(workflow_id="child-wf-1", run_id=""),
+            signal_name="my_signal",
+            child_workflow_only=True,
+        )
+    )
+
+    assert future.done() is False
+    pending = decisions.collect_pending_decisions()
+    assert len(pending) == 1
+    assert (
+        pending[0].signal_external_workflow_execution_decision_attributes.signal_name
+        == "my_signal"
+    )
+
+
+async def test_signal_external_workflow_sets_control():
+    decisions = DecisionManager(asyncio.get_event_loop())
+
+    attrs = decision.SignalExternalWorkflowExecutionDecisionAttributes(
+        domain="test-domain",
+        workflow_execution=WorkflowExecution(workflow_id="child-wf-1", run_id=""),
+        signal_name="my_signal",
+        child_workflow_only=True,
+    )
+    decisions.signal_external_workflow(attrs)
+
+    assert attrs.control == b"0"
+
+
+async def test_signal_external_workflow_multiple_signals():
+    decisions = DecisionManager(asyncio.get_event_loop())
+
+    future1 = decisions.signal_external_workflow(
+        decision.SignalExternalWorkflowExecutionDecisionAttributes(
+            domain="test-domain",
+            workflow_execution=WorkflowExecution(workflow_id="child-wf-1", run_id=""),
+            signal_name="signal_a",
+            child_workflow_only=True,
+        )
+    )
+    future2 = decisions.signal_external_workflow(
+        decision.SignalExternalWorkflowExecutionDecisionAttributes(
+            domain="test-domain",
+            workflow_execution=WorkflowExecution(workflow_id="child-wf-1", run_id=""),
+            signal_name="signal_b",
+            child_workflow_only=True,
+        )
+    )
+
+    assert len(decisions.collect_pending_decisions()) == 2
+
+    decisions.handle_history_event(signal_initiated(1, signal_id="0"))
+    decisions.handle_history_event(signal_initiated(2, signal_id="1"))
+    decisions.handle_history_event(signal_completed(3, initiated_event_id=1))
+    decisions.handle_history_event(signal_completed(4, initiated_event_id=2))
+
+    assert future1.result() is None
+    assert future2.result() is None
+
+
+async def test_signal_external_workflow_dispatch():
+    decisions = DecisionManager(asyncio.get_event_loop())
+
+    future = decisions.signal_external_workflow(
+        decision.SignalExternalWorkflowExecutionDecisionAttributes(
+            domain="test-domain",
+            workflow_execution=WorkflowExecution(workflow_id="child-wf-1", run_id=""),
+            signal_name="my_signal",
+            child_workflow_only=True,
+        )
+    )
+
+    decisions.handle_history_event(signal_initiated(1, signal_id="0"))
+    decisions.handle_history_event(signal_completed(2, initiated_event_id=1))
+
+    assert future.done() is True
+    assert future.result() is None
+
+
+async def test_signal_external_workflow_failed_dispatch():
+    decisions = DecisionManager(asyncio.get_event_loop())
+
+    future = decisions.signal_external_workflow(
+        decision.SignalExternalWorkflowExecutionDecisionAttributes(
+            domain="test-domain",
+            workflow_execution=WorkflowExecution(workflow_id="child-wf-1", run_id=""),
+            signal_name="my_signal",
+            child_workflow_only=True,
+        )
+    )
+
+    decisions.handle_history_event(signal_initiated(1, signal_id="0"))
+    decisions.handle_history_event(signal_failed(2, initiated_event_id=1))
+
+    assert future.done() is True
+    with pytest.raises(SignalExternalWorkflowFailed):
+        future.result()
+
+
+def signal_initiated(event_id: int, signal_id: str) -> history.HistoryEvent:
+    return history.HistoryEvent(
+        event_id=event_id,
+        signal_external_workflow_execution_initiated_event_attributes=history.SignalExternalWorkflowExecutionInitiatedEventAttributes(
+            control=signal_id.encode("utf-8"),
+            signal_name="my_signal",
+        ),
+    )
+
+
+def signal_completed(event_id: int, initiated_event_id: int) -> history.HistoryEvent:
+    return history.HistoryEvent(
+        event_id=event_id,
+        external_workflow_execution_signaled_event_attributes=history.ExternalWorkflowExecutionSignaledEventAttributes(
+            initiated_event_id=initiated_event_id,
+        ),
+    )
+
+
+def signal_failed(event_id: int, initiated_event_id: int) -> history.HistoryEvent:
+    return history.HistoryEvent(
+        event_id=event_id,
+        signal_external_workflow_execution_failed_event_attributes=history.SignalExternalWorkflowExecutionFailedEventAttributes(
+            initiated_event_id=initiated_event_id,
         ),
     )

--- a/tests/cadence/_internal/workflow/statemachine/test_nondeterminism.py
+++ b/tests/cadence/_internal/workflow/statemachine/test_nondeterminism.py
@@ -288,6 +288,25 @@ class TestDeterminismTracker:
             DecisionId(DecisionType.ACTIVITY, "0"), {"activity_type": "actual"}
         )
 
+    def test_signal_external_workflow_failed_event_matches_decision(self):
+        # If the server records a SignalExternalWorkflowExecutionFailed event (instead of
+        # Initiated), replay must still validate the signal decision successfully.
+        tracker = DeterminismTracker()
+        tracker.add_expectation(
+            history.HistoryEvent(
+                event_id=1,
+                signal_external_workflow_execution_failed_event_attributes=history.SignalExternalWorkflowExecutionFailedEventAttributes(
+                    control=b"0"
+                ),
+            )
+        )
+        tracker.validate_action(
+            decision.SignalExternalWorkflowExecutionDecisionAttributes(
+                control=b"0", signal_name="my-signal"
+            )
+        )
+        tracker.complete_replay()
+
     def test_expectations_out_of_order_nondeterminism(self):
         tracker = DeterminismTracker()
         tracker.add_expectation(
@@ -420,6 +439,23 @@ class TestDeterminismTracker:
                 workflow_execution=common.WorkflowExecution(workflow_id="0"),
             ),
             Expectation(DecisionId(DecisionType.CHILD_WORKFLOW, "0"), CANCEL),
+        ),
+        # Signal external workflow
+        (
+            decision.SignalExternalWorkflowExecutionDecisionAttributes(
+                control=b"0", signal_name="my-signal"
+            ),
+            Expectation(DecisionId(DecisionType.SIGNAL, "0"), {"signal_name": "my-signal"}),
+        ),
+        (
+            history.SignalExternalWorkflowExecutionInitiatedEventAttributes(
+                control=b"0", signal_name="my-signal"
+            ),
+            Expectation(DecisionId(DecisionType.SIGNAL, "0"), {"signal_name": "my-signal"}),
+        ),
+        (
+            history.SignalExternalWorkflowExecutionFailedEventAttributes(control=b"0"),
+            Expectation(DecisionId(DecisionType.SIGNAL, "0"), {}),
         ),
         # Workflow complete
         (

--- a/tests/cadence/_internal/workflow/statemachine/test_nondeterminism.py
+++ b/tests/cadence/_internal/workflow/statemachine/test_nondeterminism.py
@@ -445,13 +445,17 @@ class TestDeterminismTracker:
             decision.SignalExternalWorkflowExecutionDecisionAttributes(
                 control=b"0", signal_name="my-signal"
             ),
-            Expectation(DecisionId(DecisionType.SIGNAL, "0"), {"signal_name": "my-signal"}),
+            Expectation(
+                DecisionId(DecisionType.SIGNAL, "0"), {"signal_name": "my-signal"}
+            ),
         ),
         (
             history.SignalExternalWorkflowExecutionInitiatedEventAttributes(
                 control=b"0", signal_name="my-signal"
             ),
-            Expectation(DecisionId(DecisionType.SIGNAL, "0"), {"signal_name": "my-signal"}),
+            Expectation(
+                DecisionId(DecisionType.SIGNAL, "0"), {"signal_name": "my-signal"}
+            ),
         ),
         (
             history.SignalExternalWorkflowExecutionFailedEventAttributes(control=b"0"),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Added signal_external_workflow to DecisionManager
- Registered signal external workflow

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**