### PR TITLE
chore: move child workflow and signal-external errors to cadence.error

### DIFF
--- a/cadence/_internal/workflow/statemachine/child_workflow_execution_state_machine.py
+++ b/cadence/_internal/workflow/statemachine/child_workflow_execution_state_machine.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from cadence._internal.workflow.statemachine.decision_state_machine import (
     BaseDecisionStateMachine,
     DecisionFuture,
@@ -15,41 +13,15 @@ from cadence._internal.workflow.statemachine.nondeterminism import (
 )
 from cadence.api.v1 import decision, history
 from cadence.api.v1.common_pb2 import Payload, WorkflowExecution
+from cadence.error import (
+    ChildWorkflowExecutionCanceled,
+    ChildWorkflowExecutionFailed,
+    ChildWorkflowExecutionTerminated,
+    ChildWorkflowExecutionTimedOut,
+    StartChildWorkflowExecutionFailed,
+)
 
 child_workflow_events = EventDispatcher("initiated_event_id")
-
-
-class ChildWorkflowError(Exception):
-    """Base class for internal child workflow lifecycle errors."""
-
-
-class StartChildWorkflowExecutionFailed(ChildWorkflowError):
-    def __init__(self, message: str, cause: Any, workflow_id: str) -> None:
-        super().__init__(message)
-        self.cause = cause
-        self.workflow_id = workflow_id
-
-
-class ChildWorkflowExecutionFailed(ChildWorkflowError):
-    def __init__(self, message: str, failure: Any) -> None:
-        super().__init__(message)
-        self.failure = failure
-
-
-class ChildWorkflowExecutionCanceled(ChildWorkflowError):
-    def __init__(self, message: str, details: Any) -> None:
-        super().__init__(message)
-        self.details = details
-
-
-class ChildWorkflowExecutionTimedOut(ChildWorkflowError):
-    def __init__(self, message: str, timeout_type: int) -> None:
-        super().__init__(message)
-        self.timeout_type = timeout_type
-
-
-class ChildWorkflowExecutionTerminated(ChildWorkflowError):
-    pass
 
 
 class ChildWorkflowExecutionStateMachine(BaseDecisionStateMachine):

--- a/cadence/_internal/workflow/statemachine/signal_external_workflow_state_machine.py
+++ b/cadence/_internal/workflow/statemachine/signal_external_workflow_state_machine.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from cadence._internal.workflow.statemachine.decision_state_machine import (
     BaseDecisionStateMachine,
     DecisionFuture,
@@ -11,14 +9,9 @@ from cadence._internal.workflow.statemachine.decision_state_machine import (
 )
 from cadence._internal.workflow.statemachine.event_dispatcher import EventDispatcher
 from cadence.api.v1 import decision, history
+from cadence.error import SignalExternalWorkflowFailed
 
 signal_external_events = EventDispatcher("initiated_event_id")
-
-
-class SignalExternalWorkflowFailed(Exception):
-    def __init__(self, message: str, cause: Any) -> None:
-        super().__init__(message)
-        self.cause = cause
 
 
 class SignalExternalWorkflowStateMachine(BaseDecisionStateMachine):

--- a/cadence/error.py
+++ b/cadence/error.py
@@ -40,6 +40,45 @@ class SignalFailure(Exception):
         self.message = message
 
 
+class SignalExternalWorkflowFailed(Exception):
+    def __init__(self, message: str, cause: Any) -> None:
+        super().__init__(message)
+        self.cause = cause
+
+
+class ChildWorkflowError(Exception):
+    """Base class for child workflow lifecycle errors."""
+
+
+class StartChildWorkflowExecutionFailed(ChildWorkflowError):
+    def __init__(self, message: str, cause: Any, workflow_id: str) -> None:
+        super().__init__(message)
+        self.cause = cause
+        self.workflow_id = workflow_id
+
+
+class ChildWorkflowExecutionFailed(ChildWorkflowError):
+    def __init__(self, message: str, failure: Any) -> None:
+        super().__init__(message)
+        self.failure = failure
+
+
+class ChildWorkflowExecutionCanceled(ChildWorkflowError):
+    def __init__(self, message: str, details: Any) -> None:
+        super().__init__(message)
+        self.details = details
+
+
+class ChildWorkflowExecutionTimedOut(ChildWorkflowError):
+    def __init__(self, message: str, timeout_type: int) -> None:
+        super().__init__(message)
+        self.timeout_type = timeout_type
+
+
+class ChildWorkflowExecutionTerminated(ChildWorkflowError):
+    pass
+
+
 class CadenceRpcError(Exception):
     def __init__(self, message: str | None, code: grpc.StatusCode, *args):
         if message is None:

--- a/tests/cadence/_internal/workflow/statemachine/test_child_workflow_execution_state_machine.py
+++ b/tests/cadence/_internal/workflow/statemachine/test_child_workflow_execution_state_machine.py
@@ -1,9 +1,11 @@
 import pytest
 
 from cadence._internal.workflow.statemachine.child_workflow_execution_state_machine import (
+    ChildWorkflowExecutionStateMachine,
+)
+from cadence.error import (
     ChildWorkflowExecutionCanceled,
     ChildWorkflowExecutionFailed,
-    ChildWorkflowExecutionStateMachine,
     ChildWorkflowExecutionTerminated,
     ChildWorkflowExecutionTimedOut,
     StartChildWorkflowExecutionFailed,

--- a/tests/cadence/_internal/workflow/statemachine/test_decision_manager.py
+++ b/tests/cadence/_internal/workflow/statemachine/test_decision_manager.py
@@ -3,10 +3,7 @@ from asyncio import CancelledError
 
 import pytest
 
-from cadence._internal.workflow.statemachine.child_workflow_execution_state_machine import (
-    ChildWorkflowError,
-    StartChildWorkflowExecutionFailed,
-)
+from cadence.error import ChildWorkflowError, StartChildWorkflowExecutionFailed
 from cadence._internal.workflow.statemachine.decision_manager import DecisionManager
 from cadence._internal.workflow.statemachine.event_dispatcher import (
     EventDispatcher,

--- a/tests/cadence/_internal/workflow/statemachine/test_signal_external_workflow_state_machine.py
+++ b/tests/cadence/_internal/workflow/statemachine/test_signal_external_workflow_state_machine.py
@@ -5,9 +5,9 @@ from cadence._internal.workflow.statemachine.decision_state_machine import (
     DecisionState,
 )
 from cadence._internal.workflow.statemachine.signal_external_workflow_state_machine import (
-    SignalExternalWorkflowFailed,
     SignalExternalWorkflowStateMachine,
 )
+from cadence.error import SignalExternalWorkflowFailed
 from cadence.api.v1 import decision, history
 from cadence.api.v1.common_pb2 import WorkflowExecution
 

--- a/tests/cadence/_internal/workflow/test_context_child_workflow.py
+++ b/tests/cadence/_internal/workflow/test_context_child_workflow.py
@@ -6,14 +6,12 @@ import pytest
 from google.protobuf.duration_pb2 import Duration
 
 from cadence._internal.workflow.context import Context
-from cadence._internal.workflow.statemachine.child_workflow_execution_state_machine import (
-    ChildWorkflowExecutionFailed,
-)
 from cadence.api.v1 import workflow_pb2
 from cadence.api.v1.common_pb2 import WorkflowExecution, WorkflowType
 from cadence.api.v1.decision_pb2 import StartChildWorkflowExecutionDecisionAttributes
 from cadence.api.v1.tasklist_pb2 import TaskList, TaskListKind
 from cadence.data_converter import DefaultDataConverter
+from cadence.error import ChildWorkflowExecutionFailed
 from cadence.workflow import WorkflowInfo
 
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
move child workflow and signal-external errors to cadence.error

<!-- Tell your future self why have you made these changes -->
**Why?**
Those are not entirely internal error, user should have access to it

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**