### PR TITLE
feat: implement signal_external_workflow and signal API call for child wf

### DIFF
--- a/cadence/_internal/workflow/context.py
+++ b/cadence/_internal/workflow/context.py
@@ -10,9 +10,10 @@ from cadence._internal.workflow.deterministic_event_loop import DeterministicEve
 from cadence._internal.workflow.retry_policy import retry_policy_to_proto
 from cadence._internal.workflow.statemachine.decision_manager import DecisionManager
 from cadence.api.v1 import workflow_pb2
-from cadence.api.v1.common_pb2 import ActivityType, WorkflowType
+from cadence.api.v1.common_pb2 import ActivityType, WorkflowType, WorkflowExecution
 from cadence.api.v1.decision_pb2 import (
     ScheduleActivityTaskDecisionAttributes,
+    SignalExternalWorkflowExecutionDecisionAttributes,
     StartChildWorkflowExecutionDecisionAttributes,
     StartTimerDecisionAttributes,
 )
@@ -206,6 +207,32 @@ class Context(WorkflowContext):
 
         return schedule_attributes
 
+    async def signal_child_workflow(
+        self,
+        child_workflow_id: str,
+        signal_name: str,
+        *args: Any,
+    ) -> None:
+        if not child_workflow_id:
+            raise ValueError("child_workflow_id must not be empty")
+        await self._signal_workflow(
+            child_workflow_id, signal_name, args, child_workflow_only=True
+        )
+
+    async def signal_external_workflow(
+        self,
+        workflow_id: str,
+        signal_name: str,
+        *args: Any,
+        run_id: str = "",
+        domain: str = "",
+    ) -> None:
+        if not workflow_id:
+            raise ValueError("workflow_id must not be empty")
+        await self._signal_workflow(
+            workflow_id, signal_name, args, run_id=run_id, domain=domain
+        )
+
     async def start_timer(self, duration: timedelta):
         if duration.total_seconds() <= 0:  # shortcut
             return
@@ -243,6 +270,30 @@ class Context(WorkflowContext):
             yield self
         finally:
             WorkflowContext._var.reset(token)
+
+    async def _signal_workflow(
+        self,
+        workflow_id: str,
+        signal_name: str,
+        args: tuple,
+        *,
+        run_id: str = "",
+        domain: str = "",
+        child_workflow_only: bool = False,
+    ) -> None:
+        if not signal_name:
+            raise ValueError("signal_name must not be empty")
+        attrs = SignalExternalWorkflowExecutionDecisionAttributes(
+            domain=domain or self._info.workflow_domain,
+            workflow_execution=WorkflowExecution(
+                workflow_id=workflow_id,
+                run_id=run_id,
+            ),
+            signal_name=signal_name,
+            input=self.data_converter().to_data(list(args)),
+            child_workflow_only=child_workflow_only,
+        )
+        await self._decision_manager.signal_external_workflow(attrs)
 
 
 def _round_to_nearest_second(delta: timedelta) -> timedelta:

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -101,6 +101,11 @@ class ChildWorkflowFuture(Awaitable[ResultType]):
         """Request cancellation of the child workflow."""
         return self._result_future.cancel()
 
+    async def signal(self, signal_name: str, *args: Any) -> None:
+        """Send a signal to this child workflow."""
+        ctx = WorkflowContext.get()
+        await ctx.signal_child_workflow(self._workflow_id, signal_name, *args)
+
     def __await__(self) -> Generator[Any, None, ResultType]:
         payload: Payload = yield from self._result_future.__await__()
         result = self._data_converter.from_data(payload, [self._result_type])[0]
@@ -137,6 +142,27 @@ async def start_child_workflow(
 ) -> "ChildWorkflowFuture[ResultType]":
     return await WorkflowContext.get().start_child_workflow(
         workflow_type, result_type, *args, **kwargs
+    )
+
+
+async def signal_external_workflow(
+    workflow_id: str,
+    signal_name: str,
+    *args: Any,
+    run_id: str = "",
+    domain: str = "",
+) -> None:
+    """Send a signal to an external workflow execution.
+
+    Args:
+        workflow_id: Target workflow ID.
+        signal_name: Name of the signal to deliver.
+        *args: Signal payload arguments, serialized via DataConverter.
+        run_id: Target run ID. Empty string targets the currently running execution.
+        domain: Target domain. Empty string defaults to the current workflow's domain.
+    """
+    await WorkflowContext.get().signal_external_workflow(
+        workflow_id, signal_name, *args, run_id=run_id, domain=domain
     )
 
 
@@ -538,6 +564,24 @@ class WorkflowContext(ABC):
         *args: Any,
         **kwargs: Unpack[ChildWorkflowOptions],
     ) -> "ChildWorkflowFuture[ResultType]": ...
+
+    @abstractmethod
+    async def signal_child_workflow(
+        self,
+        child_workflow_id: str,
+        signal_name: str,
+        *args: Any,
+    ) -> None: ...
+
+    @abstractmethod
+    async def signal_external_workflow(
+        self,
+        workflow_id: str,
+        signal_name: str,
+        *args: Any,
+        run_id: str = "",
+        domain: str = "",
+    ) -> None: ...
 
     @abstractmethod
     async def start_timer(self, duration: timedelta) -> None: ...

--- a/tests/cadence/_internal/workflow/test_context_signal_child_workflow.py
+++ b/tests/cadence/_internal/workflow/test_context_signal_child_workflow.py
@@ -1,0 +1,256 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cadence._internal.workflow.context import Context
+from cadence.api.v1.decision_pb2 import (
+    SignalExternalWorkflowExecutionDecisionAttributes,
+)
+from cadence.data_converter import DefaultDataConverter
+from cadence.workflow import WorkflowInfo
+
+
+def _make_ctx() -> tuple[Context, MagicMock]:
+    dm = MagicMock()
+    dc = DefaultDataConverter()
+    info = WorkflowInfo(
+        workflow_type="ParentWf",
+        workflow_domain="domain",
+        workflow_id="wid",
+        workflow_run_id="rid",
+        workflow_task_list="tl",
+        data_converter=dc,
+    )
+    ctx = Context(info, dm)
+    return ctx, dm
+
+
+def _setup_signal_mock(
+    dm: MagicMock,
+    loop: asyncio.AbstractEventLoop | None = None,
+) -> None:
+    loop = loop or asyncio.get_event_loop()
+    future: asyncio.Future[None] = loop.create_future()
+    future.set_result(None)
+    dm.signal_external_workflow = MagicMock(return_value=future)
+
+
+def _attrs(dm: MagicMock) -> SignalExternalWorkflowExecutionDecisionAttributes:
+    return dm.signal_external_workflow.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# signal_child_workflow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_signal_child_workflow_basic():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    await ctx.signal_child_workflow("child-wf-1", "my_signal", "arg1")
+
+    dm.signal_external_workflow.assert_called_once()
+    attrs = _attrs(dm)
+    assert attrs.signal_name == "my_signal"
+    assert attrs.workflow_execution.workflow_id == "child-wf-1"
+    assert attrs.domain == "domain"
+
+
+@pytest.mark.asyncio
+async def test_signal_child_workflow_serializes_args():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+    dc = DefaultDataConverter()
+
+    await ctx.signal_child_workflow("child-wf-1", "my_signal", "hello", 42)
+
+    deserialized = dc.from_data(_attrs(dm).input, [str, int])
+    assert deserialized == ["hello", 42]
+
+
+@pytest.mark.asyncio
+async def test_signal_child_workflow_sets_child_workflow_only():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    await ctx.signal_child_workflow("child-wf-1", "my_signal")
+
+    assert _attrs(dm).child_workflow_only is True
+
+
+@pytest.mark.asyncio
+async def test_signal_child_workflow_uses_empty_run_id():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    await ctx.signal_child_workflow("child-wf-1", "my_signal")
+
+    assert _attrs(dm).workflow_execution.run_id == ""
+
+
+@pytest.mark.asyncio
+async def test_signal_child_workflow_rejects_empty_id():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    with pytest.raises(ValueError, match="child_workflow_id must not be empty"):
+        await ctx.signal_child_workflow("", "my_signal")
+
+    dm.signal_external_workflow.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# signal_external_workflow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_signal_external_workflow_basic():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    await ctx.signal_external_workflow("ext-wf-1", "ping")
+
+    dm.signal_external_workflow.assert_called_once()
+    attrs = _attrs(dm)
+    assert attrs.signal_name == "ping"
+    assert attrs.workflow_execution.workflow_id == "ext-wf-1"
+    assert attrs.child_workflow_only is False
+
+
+@pytest.mark.asyncio
+async def test_signal_external_workflow_defaults_to_own_domain():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    await ctx.signal_external_workflow("ext-wf-1", "ping")
+
+    assert _attrs(dm).domain == "domain"
+
+
+@pytest.mark.asyncio
+async def test_signal_external_workflow_custom_domain():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    await ctx.signal_external_workflow("ext-wf-1", "ping", domain="other-domain")
+
+    assert _attrs(dm).domain == "other-domain"
+
+
+@pytest.mark.asyncio
+async def test_signal_external_workflow_forwards_run_id():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    await ctx.signal_external_workflow("ext-wf-1", "ping", run_id="run-42")
+
+    assert _attrs(dm).workflow_execution.run_id == "run-42"
+
+
+@pytest.mark.asyncio
+async def test_signal_external_workflow_default_run_id_is_empty():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    await ctx.signal_external_workflow("ext-wf-1", "ping")
+
+    assert _attrs(dm).workflow_execution.run_id == ""
+
+
+@pytest.mark.asyncio
+async def test_signal_external_workflow_serializes_args():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+    dc = DefaultDataConverter()
+
+    await ctx.signal_external_workflow("ext-wf-1", "ping", "hello", 99)
+
+    deserialized = dc.from_data(_attrs(dm).input, [str, int])
+    assert deserialized == ["hello", 99]
+
+
+@pytest.mark.asyncio
+async def test_signal_external_workflow_rejects_empty_id():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    with pytest.raises(ValueError, match="workflow_id must not be empty"):
+        await ctx.signal_external_workflow("", "ping")
+
+    dm.signal_external_workflow.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_signal_external_workflow_rejects_empty_signal_name():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    with pytest.raises(ValueError, match="signal_name must not be empty"):
+        await ctx.signal_external_workflow("wf-1", "")
+
+    dm.signal_external_workflow.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_signal_child_workflow_rejects_empty_signal_name():
+    ctx, dm = _make_ctx()
+    _setup_signal_mock(dm)
+
+    with pytest.raises(ValueError, match="signal_name must not be empty"):
+        await ctx.signal_child_workflow("child-wf-1", "")
+
+    dm.signal_external_workflow.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ChildWorkflowFuture.signal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_child_workflow_future_signal_delegates_to_context():
+    from cadence.workflow import ChildWorkflowFuture
+
+    dc = DefaultDataConverter()
+    loop = asyncio.get_event_loop()
+    result_future: asyncio.Future = loop.create_future()
+
+    future = ChildWorkflowFuture(
+        workflow_id="child-wf-1",
+        run_id="",
+        result_future=result_future,
+        result_type=str,
+        data_converter=dc,
+    )
+
+    mock_ctx = AsyncMock()
+    with patch("cadence.workflow.WorkflowContext.get", return_value=mock_ctx):
+        await future.signal("hello_signal", "arg1", "arg2")
+
+    mock_ctx.signal_child_workflow.assert_awaited_once_with(
+        "child-wf-1", "hello_signal", "arg1", "arg2"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public cadence.workflow.signal_external_workflow wrapper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_public_signal_external_workflow_delegates():
+    import cadence.workflow as wf
+
+    mock_ctx = AsyncMock()
+    with patch("cadence.workflow.WorkflowContext.get", return_value=mock_ctx):
+        await wf.signal_external_workflow(
+            "wf-id", "my_signal", "a", run_id="r1", domain="d1"
+        )
+
+    mock_ctx.signal_external_workflow.assert_awaited_once_with(
+        "wf-id", "my_signal", "a", run_id="r1", domain="d1"
+    )

--- a/tests/cadence/_internal/workflow/test_context_signal_child_workflow.py
+++ b/tests/cadence/_internal/workflow/test_context_signal_child_workflow.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -34,7 +35,10 @@ def _setup_signal_mock(dm: MagicMock) -> None:
 
 
 def _attrs(dm: MagicMock) -> SignalExternalWorkflowExecutionDecisionAttributes:
-    return dm.signal_external_workflow.call_args[0][0]
+    return cast(
+        SignalExternalWorkflowExecutionDecisionAttributes,
+        dm.signal_external_workflow.call_args[0][0],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cadence/_internal/workflow/test_context_signal_child_workflow.py
+++ b/tests/cadence/_internal/workflow/test_context_signal_child_workflow.py
@@ -26,11 +26,8 @@ def _make_ctx() -> tuple[Context, MagicMock]:
     return ctx, dm
 
 
-def _setup_signal_mock(
-    dm: MagicMock,
-    loop: asyncio.AbstractEventLoop | None = None,
-) -> None:
-    loop = loop or asyncio.get_event_loop()
+def _setup_signal_mock(dm: MagicMock) -> None:
+    loop = asyncio.get_running_loop()
     future: asyncio.Future[None] = loop.create_future()
     future.set_result(None)
     dm.signal_external_workflow = MagicMock(return_value=future)
@@ -216,8 +213,7 @@ async def test_child_workflow_future_signal_delegates_to_context():
     from cadence.workflow import ChildWorkflowFuture
 
     dc = DefaultDataConverter()
-    loop = asyncio.get_event_loop()
-    result_future: asyncio.Future = loop.create_future()
+    result_future: asyncio.Future = asyncio.get_running_loop().create_future()
 
     future = ChildWorkflowFuture(
         workflow_id="child-wf-1",

--- a/tests/integration_tests/workflow/test_child_workflow.py
+++ b/tests/integration_tests/workflow/test_child_workflow.py
@@ -1,5 +1,5 @@
+import uuid
 from datetime import timedelta
-
 
 from cadence import Registry, workflow
 from cadence.api.v1.history_pb2 import EventFilterType
@@ -55,6 +55,52 @@ class ParentStartsChildWorkflow:
         return await handle
 
 
+@reg.workflow()
+class ChildWaitsForSignalWorkflow:
+    """Child blocks until it receives ``append``; used for in-workflow signal APIs."""
+
+    def __init__(self) -> None:
+        self.received: list[str] = []
+
+    @workflow.run
+    async def run(self) -> str:
+        await workflow.wait_condition(lambda: len(self.received) >= 1)
+        return ",".join(self.received)
+
+    @workflow.signal(name="append")
+    def append(self, value: str) -> None:
+        self.received.append(value)
+
+
+@reg.workflow()
+class ParentSignalsChildViaHandle:
+    @workflow.run
+    async def run(self) -> str:
+        run_id = WorkflowContext.get().info().workflow_run_id
+        child_workflow_id = f"{run_id}-child-signal-via-handle"
+        handle = await workflow.start_child_workflow(
+            "ChildWaitsForSignalWorkflow",
+            str,
+            workflow_id=child_workflow_id,
+            execution_start_to_close_timeout=timedelta(seconds=30),
+            task_start_to_close_timeout=timedelta(seconds=10),
+        )
+        await handle.signal("append", "from-parent-handle")
+        return await handle
+
+
+@reg.workflow()
+class ParentSignalsExternalByWorkflowId:
+    """Signals another open execution by workflow ID (``signal_external_workflow``)."""
+
+    @workflow.run
+    async def run(self, target_workflow_id: str) -> str:
+        await workflow.signal_external_workflow(
+            target_workflow_id, "append", "from-external-decision"
+        )
+        return "sent"
+
+
 async def test_execute_child_workflow_end_to_end(helper: CadenceHelper):
     async with helper.worker(reg) as worker:
         execution = await worker.client.start_workflow(
@@ -104,6 +150,82 @@ async def test_start_child_workflow_end_to_end(helper: CadenceHelper):
         assert (
             '"child:hello world"'
             == response.history.events[
+                -1
+            ].workflow_execution_completed_event_attributes.result.data.decode()
+        )
+
+
+async def test_child_workflow_future_signal_end_to_end(helper: CadenceHelper):
+    async with helper.worker(reg) as worker:
+        execution = await worker.client.start_workflow(
+            "ParentSignalsChildViaHandle",
+            task_list=worker.task_list,
+            execution_start_to_close_timeout=timedelta(seconds=30),
+        )
+
+        response: GetWorkflowExecutionHistoryResponse = await worker.client.workflow_stub.GetWorkflowExecutionHistory(
+            GetWorkflowExecutionHistoryRequest(
+                domain=DOMAIN_NAME,
+                workflow_execution=execution,
+                wait_for_new_event=True,
+                history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_CLOSE_EVENT,
+                skip_archival=True,
+            )
+        )
+
+        assert (
+            '"from-parent-handle"'
+            == response.history.events[
+                -1
+            ].workflow_execution_completed_event_attributes.result.data.decode()
+        )
+
+
+async def test_signal_external_workflow_end_to_end(helper: CadenceHelper):
+    target_workflow_id = f"ext-signal-target-{uuid.uuid4().hex}"
+    async with helper.worker(reg) as worker:
+        target_exec = await worker.client.start_workflow(
+            "ChildWaitsForSignalWorkflow",
+            task_list=worker.task_list,
+            workflow_id=target_workflow_id,
+            execution_start_to_close_timeout=timedelta(seconds=30),
+        )
+
+        sender_exec = await worker.client.start_workflow(
+            "ParentSignalsExternalByWorkflowId",
+            target_workflow_id,
+            task_list=worker.task_list,
+            execution_start_to_close_timeout=timedelta(seconds=30),
+        )
+
+        target_response: GetWorkflowExecutionHistoryResponse = await worker.client.workflow_stub.GetWorkflowExecutionHistory(
+            GetWorkflowExecutionHistoryRequest(
+                domain=DOMAIN_NAME,
+                workflow_execution=target_exec,
+                wait_for_new_event=True,
+                history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_CLOSE_EVENT,
+                skip_archival=True,
+            )
+        )
+        assert (
+            '"from-external-decision"'
+            == target_response.history.events[
+                -1
+            ].workflow_execution_completed_event_attributes.result.data.decode()
+        )
+
+        sender_response: GetWorkflowExecutionHistoryResponse = await worker.client.workflow_stub.GetWorkflowExecutionHistory(
+            GetWorkflowExecutionHistoryRequest(
+                domain=DOMAIN_NAME,
+                workflow_execution=sender_exec,
+                wait_for_new_event=True,
+                history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_CLOSE_EVENT,
+                skip_archival=True,
+            )
+        )
+        assert (
+            '"sent"'
+            == sender_response.history.events[
                 -1
             ].workflow_execution_completed_event_attributes.result.data.decode()
         )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Added workflow APIs to send signals via Cadence’s **SignalExternalWorkflowExecution** decision
- Added **`signal_child_workflow()`** on the internal context

<!-- Tell your future self why have you made these changes -->
**Why?**
those are important feature

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**