### PR TITLE
feat: Add memo support for workflow and child workflow starts

### DIFF
--- a/cadence/_internal/workflow/context.py
+++ b/cadence/_internal/workflow/context.py
@@ -7,6 +7,7 @@ from math import ceil
 from typing import Iterator, Optional, Any, Unpack, Type, cast, Callable
 
 from cadence._internal.workflow.deterministic_event_loop import DeterministicEventLoop
+from cadence._internal.workflow.memo import memo_to_proto
 from cadence._internal.workflow.retry_policy import retry_policy_to_proto
 from cadence._internal.workflow.statemachine.decision_manager import DecisionManager
 from cadence.api.v1 import workflow_pb2
@@ -204,6 +205,10 @@ class Context(WorkflowContext):
         cron_schedule = kwargs.get("cron_schedule")
         if cron_schedule:
             schedule_attributes.cron_schedule = cron_schedule
+
+        memo_proto = memo_to_proto(self.data_converter(), kwargs.get("memo"))
+        if memo_proto is not None:
+            schedule_attributes.memo.CopyFrom(memo_proto)
 
         return schedule_attributes
 

--- a/cadence/_internal/workflow/memo.py
+++ b/cadence/_internal/workflow/memo.py
@@ -1,4 +1,4 @@
-"""Convert user memo maps to protobuf :class:`cadence.api.v1.common_pb2.Memo`."""
+"""Convert user memo maps to/from protobuf :class:`cadence.api.v1.common_pb2.Memo`."""
 
 from __future__ import annotations
 
@@ -23,3 +23,18 @@ def memo_to_proto(
     for key, value in memo.items():
         out.fields[key].CopyFrom(data_converter.to_data([value]))
     return out
+
+
+def memo_from_proto(
+    data_converter: DataConverter,
+    memo: common_pb2.Memo,
+) -> dict[str, Any]:
+    """Deserialize a protobuf ``Memo`` back to a plain dict.
+
+    Each field payload was encoded as a single-element list; we unwrap that
+    first element to recover the original value.
+    """
+    return {
+        key: data_converter.from_data(payload, [None])[0]
+        for key, payload in memo.fields.items()
+    }

--- a/cadence/_internal/workflow/memo.py
+++ b/cadence/_internal/workflow/memo.py
@@ -1,0 +1,25 @@
+"""Convert user memo maps to protobuf :class:`cadence.api.v1.common_pb2.Memo`."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from cadence.api.v1 import common_pb2
+from cadence.data_converter import DataConverter
+
+
+def memo_to_proto(
+    data_converter: DataConverter,
+    memo: Mapping[str, Any] | None,
+) -> common_pb2.Memo | None:
+    """Serialize ``memo`` to protobuf, or ``None`` if no memo was provided.
+
+    Each value is encoded as a single-element list via the data converter,
+    matching Go/Java SDK behavior (one :class:`Payload` per key).
+    """
+    if not memo:
+        return None
+    out = common_pb2.Memo()
+    for key, value in memo.items():
+        out.fields[key].CopyFrom(data_converter.to_data([value]))
+    return out

--- a/cadence/client.py
+++ b/cadence/client.py
@@ -15,6 +15,7 @@ from cadence._internal.rpc.yarpc import YarpcMetadataInterceptor
 from cadence._internal.workflow.active_cluster_selection_policy import (
     active_cluster_selection_policy_to_proto,
 )
+from cadence._internal.workflow.memo import memo_to_proto
 from cadence._internal.workflow.retry_policy import retry_policy_to_proto
 from cadence.api.v1 import schedule_pb2
 from cadence.api.v1.common_pb2 import (
@@ -84,6 +85,7 @@ class StartWorkflowOptions(TypedDict, total=False):
     workflow_id_reuse_policy: workflow_pb2.WorkflowIdReusePolicy
     retry_policy: RetryPolicy
     active_cluster_selection_policy: ActiveClusterSelectionPolicy
+    memo: dict[str, Any]
 
 
 def _validate_and_apply_defaults(
@@ -318,6 +320,10 @@ class Client:
         )
         if acsp_proto is not None:
             request.active_cluster_selection_policy.CopyFrom(acsp_proto)
+
+        memo_proto = memo_to_proto(self.data_converter, options.get("memo"))
+        if memo_proto is not None:
+            request.memo.CopyFrom(memo_proto)
 
         return request
 

--- a/cadence/worker/_decision_task_handler.py
+++ b/cadence/worker/_decision_task_handler.py
@@ -4,6 +4,7 @@ import logging
 from typing import Optional
 
 from cadence._internal.workflow.history_event_iterator import iterate_history_events
+from cadence._internal.workflow.memo import memo_from_proto
 from cadence.api.v1.common_pb2 import Payload
 from cadence.api.v1.service_worker_pb2 import (
     PollForDecisionTaskResponse,
@@ -119,6 +120,13 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
             event async for event in iterate_history_events(task, self._client)
         ]
 
+        started_attrs = workflow_events[0].workflow_execution_started_event_attributes
+        memo = (
+            memo_from_proto(self._client.data_converter, started_attrs.memo)
+            if started_attrs.HasField("memo")
+            else None
+        )
+
         workflow_info = WorkflowInfo(
             workflow_type=workflow_type_name,
             workflow_domain=self._client.domain,
@@ -126,6 +134,7 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
             workflow_run_id=run_id,
             workflow_task_list=self.task_list,
             data_converter=self._client.data_converter,
+            memo=memo,
         )
 
         workflow_engine = WorkflowEngine(

--- a/cadence/worker/_decision_task_handler.py
+++ b/cadence/worker/_decision_task_handler.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from cadence._internal.workflow.history_event_iterator import iterate_history_events
 from cadence._internal.workflow.memo import memo_from_proto
+from cadence.api.v1.history_pb2 import HistoryEvent, WorkflowExecutionStartedEventAttributes
 from cadence.api.v1.common_pb2 import Payload
 from cadence.api.v1.service_worker_pb2 import (
     PollForDecisionTaskResponse,
@@ -120,7 +121,17 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
             event async for event in iterate_history_events(task, self._client)
         ]
 
+        if not workflow_events:
+            raise ValueError(
+                "Workflow history yielded no events; cannot process decision task."
+            )
+
         started_attrs = workflow_events[0].workflow_execution_started_event_attributes
+        if started_attrs is None:
+            raise ValueError(
+                "Workflow history does not contain a WorkflowExecutionStarted event."
+            )
+
         memo = (
             memo_from_proto(self._client.data_converter, started_attrs.memo)
             if started_attrs.HasField("memo")

--- a/cadence/worker/_decision_task_handler.py
+++ b/cadence/worker/_decision_task_handler.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 from cadence._internal.workflow.history_event_iterator import iterate_history_events
 from cadence._internal.workflow.memo import memo_from_proto
-from cadence.api.v1.history_pb2 import HistoryEvent, WorkflowExecutionStartedEventAttributes
 from cadence.api.v1.common_pb2 import Payload
 from cadence.api.v1.service_worker_pb2 import (
     PollForDecisionTaskResponse,
@@ -126,11 +125,13 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
                 "Workflow history yielded no events; cannot process decision task."
             )
 
-        started_attrs = workflow_events[0].workflow_execution_started_event_attributes
-        if started_attrs is None:
+        if not workflow_events[0].HasField(
+            "workflow_execution_started_event_attributes"
+        ):
             raise ValueError(
                 "Workflow history does not contain a WorkflowExecutionStarted event."
             )
+        started_attrs = workflow_events[0].workflow_execution_started_event_attributes
 
         memo = (
             memo_from_proto(self._client.data_converter, started_attrs.memo)

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -72,6 +72,7 @@ class ChildWorkflowOptions(TypedDict, total=False):
     workflow_id_reuse_policy: Union[workflow_pb2.WorkflowIdReusePolicy, str]
     retry_policy: RetryPolicy
     cron_schedule: str
+    memo: dict[str, Any]
 
 
 class ChildWorkflowFuture(Awaitable[ResultType]):

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -528,6 +528,7 @@ class WorkflowInfo:
     workflow_run_id: str
     workflow_task_list: str
     data_converter: DataConverter
+    memo: dict[str, Any] | None = None
 
 
 class WorkflowContext(ABC):

--- a/tests/cadence/_internal/workflow/test_context_child_workflow.py
+++ b/tests/cadence/_internal/workflow/test_context_child_workflow.py
@@ -94,6 +94,27 @@ async def test_execute_child_workflow_basic():
 
 
 @pytest.mark.asyncio
+async def test_execute_child_workflow_with_memo():
+    ctx, dm = _make_ctx()
+    _setup_schedule_mock(dm)
+    dc = ctx.data_converter()
+
+    await ctx.execute_child_workflow(
+        "ChildWf",
+        str,
+        execution_start_to_close_timeout=timedelta(minutes=10),
+        memo={"k1": "v1", "k2": 99},
+    )
+
+    attrs: StartChildWorkflowExecutionDecisionAttributes = (
+        dm.schedule_child_workflow.call_args[0][0]
+    )
+    assert len(attrs.memo.fields) == 2
+    assert attrs.memo.fields["k1"] == dc.to_data(["v1"])
+    assert attrs.memo.fields["k2"] == dc.to_data([99])
+
+
+@pytest.mark.asyncio
 async def test_execute_child_workflow_auto_generates_workflow_id():
     ctx, dm = _make_ctx(run_id="test-run-id")
     _setup_schedule_mock(dm)

--- a/tests/cadence/_internal/workflow/test_memo.py
+++ b/tests/cadence/_internal/workflow/test_memo.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+
+import pytest
+
+from cadence._internal.workflow.memo import memo_to_proto
+from cadence.data_converter import DefaultDataConverter
+
+
+def test_memo_to_proto_none() -> None:
+    dc = DefaultDataConverter()
+    assert memo_to_proto(dc, None) is None
+
+
+def test_memo_to_proto_empty_dict() -> None:
+    dc = DefaultDataConverter()
+    assert memo_to_proto(dc, {}) is None
+
+
+def test_memo_to_proto_single_key_matches_to_data() -> None:
+    dc = DefaultDataConverter()
+    proto = memo_to_proto(dc, {"k": "v"})
+    assert proto is not None
+    assert list(proto.fields.keys()) == ["k"]
+    assert proto.fields["k"] == dc.to_data(["v"])
+
+
+def test_memo_to_proto_multiple_keys() -> None:
+    dc = DefaultDataConverter()
+    proto = memo_to_proto(dc, {"a": 1, "b": "two", "c": {"x": 3}})
+    assert proto is not None
+    assert proto.fields["a"] == dc.to_data([1])
+    assert proto.fields["b"] == dc.to_data(["two"])
+    assert proto.fields["c"] == dc.to_data([{"x": 3}])
+
+
+@dataclass
+class _Sample:
+    x: int
+    y: str
+
+
+def test_memo_to_proto_dataclass_value() -> None:
+    dc = DefaultDataConverter()
+    obj = _Sample(7, "z")
+    proto = memo_to_proto(dc, {"obj": obj})
+    assert proto is not None
+    assert proto.fields["obj"] == dc.to_data([obj])
+
+
+def test_memo_to_proto_encoding_error_propagates() -> None:
+    dc = DefaultDataConverter()
+    with pytest.raises(Exception):
+        memo_to_proto(dc, {"bad": object()})

--- a/tests/cadence/test_client_workflow.py
+++ b/tests/cadence/test_client_workflow.py
@@ -217,6 +217,32 @@ class TestClientBuildStartWorkflowRequest:
         assert len(request.input.data) > 0
 
     @pytest.mark.asyncio
+    async def test_build_request_without_memo_has_no_memo_fields(self, mock_client):
+        client = Client(domain="test-domain", target="localhost:7933")
+        options = StartWorkflowOptions(
+            task_list="test-task-list",
+            execution_start_to_close_timeout=timedelta(minutes=10),
+            task_start_to_close_timeout=timedelta(seconds=30),
+        )
+        request = client._build_start_workflow_request("TestWorkflow", (), options)
+        assert len(request.memo.fields) == 0
+
+    @pytest.mark.asyncio
+    async def test_build_request_with_memo(self, mock_client):
+        client = Client(domain="test-domain", target="localhost:7933")
+        dc = client.data_converter
+        options = StartWorkflowOptions(
+            task_list="test-task-list",
+            execution_start_to_close_timeout=timedelta(minutes=10),
+            task_start_to_close_timeout=timedelta(seconds=30),
+            memo={"tenant": "acme", "count": 42},
+        )
+        request = client._build_start_workflow_request("TestWorkflow", (), options)
+        assert len(request.memo.fields) == 2
+        assert request.memo.fields["tenant"] == dc.to_data(["acme"])
+        assert request.memo.fields["count"] == dc.to_data([42])
+
+    @pytest.mark.asyncio
     async def test_build_request_with_timeouts(self, mock_client):
         """Test building request with timeout settings."""
         client = Client(domain="test-domain", target="localhost:7933")

--- a/tests/cadence/worker/test_decision_task_handler.py
+++ b/tests/cadence/worker/test_decision_task_handler.py
@@ -1,8 +1,12 @@
 import pytest
 from unittest.mock import Mock, AsyncMock, patch, PropertyMock
 
-from cadence.api.v1.common_pb2 import Payload
-from cadence.api.v1.history_pb2 import History
+from cadence.api.v1.common_pb2 import Memo, Payload
+from cadence.api.v1.history_pb2 import (
+    History,
+    HistoryEvent,
+    WorkflowExecutionStartedEventAttributes,
+)
 from cadence.api.v1.service_worker_pb2 import (
     PollForDecisionTaskResponse,
     RespondDecisionTaskCompletedRequest,
@@ -10,6 +14,7 @@ from cadence.api.v1.service_worker_pb2 import (
 from cadence.api.v1.workflow_pb2 import DecisionTaskFailedCause
 from cadence.api.v1.decision_pb2 import Decision
 from cadence.client import Client
+from cadence.data_converter import DefaultDataConverter
 from cadence.worker._decision_task_handler import DecisionTaskHandler
 from cadence.worker._registry import Registry
 from cadence._internal.workflow.workflow_engine import WorkflowEngine, DecisionResult
@@ -28,6 +33,7 @@ class TestDecisionTaskHandler:
         client.worker_stub.RespondDecisionTaskCompleted = AsyncMock()
         client.worker_stub.RespondDecisionTaskFailed = AsyncMock()
         client.worker_stub.RespondQueryTaskCompleted = AsyncMock()
+        client.data_converter = DefaultDataConverter()
         type(client).domain = PropertyMock(return_value="test_domain")
         return client
 
@@ -57,12 +63,19 @@ class TestDecisionTaskHandler:
         task.workflow_execution.run_id = "test_run_id"
         task.workflow_type = Mock()
         task.workflow_type.name = "TestWorkflow"
-        # Add the missing attributes that are now accessed directly
         task.started_event_id = 1
         task.attempt = 1
-        task.history = History()
         task.next_page_token = b""
         task.HasField = Mock(return_value=False)
+
+        memo = Memo()
+        memo.fields["env"].CopyFrom(Payload(data=b'"prod"'))
+        started = HistoryEvent(
+            workflow_execution_started_event_attributes=WorkflowExecutionStartedEventAttributes(
+                memo=memo
+            )
+        )
+        task.history = History(events=[started])
         return task
 
     def test_initialization(self, mock_client, mock_registry):
@@ -227,7 +240,13 @@ class TestDecisionTaskHandler:
         task1.workflow_type.name = "TestWorkflow"
         task1.started_event_id = 1
         task1.attempt = 1
-        task1.history = History()
+        task1.history = History(
+            events=[
+                HistoryEvent(
+                    workflow_execution_started_event_attributes=WorkflowExecutionStartedEventAttributes()
+                )
+            ]
+        )
         task1.next_page_token = b""
         task1.HasField = Mock(return_value=False)
 
@@ -240,7 +259,13 @@ class TestDecisionTaskHandler:
         task2.workflow_type.name = "TestWorkflow"
         task2.started_event_id = 2
         task2.attempt = 1
-        task2.history = History()
+        task2.history = History(
+            events=[
+                HistoryEvent(
+                    workflow_execution_started_event_attributes=WorkflowExecutionStartedEventAttributes()
+                )
+            ]
+        )
         task2.next_page_token = b""
         task2.HasField = Mock(return_value=False)
 
@@ -453,6 +478,7 @@ class TestDecisionTaskHandler:
                         "workflow_run_id": "test_run_id",
                         "workflow_task_list": "test_task_list",
                         "data_converter": handler._client.data_converter,
+                        "memo": {"env": "prod"},
                     }
 
                 # Verify WorkflowEngine was created with correct parameters

--- a/tests/cadence/worker/test_task_handler_integration.py
+++ b/tests/cadence/worker/test_task_handler_integration.py
@@ -2,7 +2,11 @@ import pytest
 from contextlib import contextmanager
 from unittest.mock import Mock, AsyncMock, patch, PropertyMock
 
-from cadence.api.v1.history_pb2 import History
+from cadence.api.v1.history_pb2 import (
+    History,
+    HistoryEvent,
+    WorkflowExecutionStartedEventAttributes,
+)
 from cadence.api.v1.service_worker_pb2 import PollForDecisionTaskResponse
 from cadence.client import Client
 from cadence.worker._decision_task_handler import DecisionTaskHandler
@@ -55,7 +59,13 @@ class TestTaskHandlerIntegration:
         # Add the missing attributes that are now accessed directly
         task.started_event_id = 1
         task.attempt = 1
-        task.history = History()
+        task.history = History(
+            events=[
+                HistoryEvent(
+                    workflow_execution_started_event_attributes=WorkflowExecutionStartedEventAttributes()
+                )
+            ]
+        )
         task.next_page_token = b""
         task.HasField = Mock(return_value=False)
         return task
@@ -207,7 +217,13 @@ class TestTaskHandlerIntegration:
         task1.workflow_type.name = "TestWorkflow"
         task1.started_event_id = 1
         task1.attempt = 1
-        task1.history = History()
+        task1.history = History(
+            events=[
+                HistoryEvent(
+                    workflow_execution_started_event_attributes=WorkflowExecutionStartedEventAttributes()
+                )
+            ]
+        )
         task1.next_page_token = b""
         task1.HasField = Mock(return_value=False)
 
@@ -220,7 +236,13 @@ class TestTaskHandlerIntegration:
         task2.workflow_type.name = "TestWorkflow"
         task2.started_event_id = 2
         task2.attempt = 1
-        task2.history = History()
+        task2.history = History(
+            events=[
+                HistoryEvent(
+                    workflow_execution_started_event_attributes=WorkflowExecutionStartedEventAttributes()
+                )
+            ]
+        )
         task2.next_page_token = b""
         task2.HasField = Mock(return_value=False)
 
@@ -362,7 +384,13 @@ class TestTaskHandlerIntegration:
             task.workflow_type.name = "TestWorkflow"
             task.started_event_id = i + 1
             task.attempt = 1
-            task.history = History()
+            task.history = History(
+                events=[
+                    HistoryEvent(
+                        workflow_execution_started_event_attributes=WorkflowExecutionStartedEventAttributes()
+                    )
+                ]
+            )
             task.next_page_token = b""
             task.HasField = Mock(return_value=False)
             tasks.append(task)

--- a/tests/integration_tests/test_schedule.py
+++ b/tests/integration_tests/test_schedule.py
@@ -47,6 +47,9 @@ def _assert_describe_spec_and_action(
 
 
 @pytest.mark.usefixtures("helper")
+@pytest.mark.skip(
+    reason="skip this test because it is not working as expected, see https://github.com/cadence-workflow/cadence-python-client/issues/117"
+)
 async def test_create_describe_delete(helper: CadenceHelper):
     """Create a schedule, describe it to verify spec round-trips, then delete it."""
     schedule_id = f"test-schedule-{uuid.uuid4()}"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Implement memo for workflow and child wf start

Also mark a schedule test as flaky ([issue](https://github.com/cadence-workflow/cadence-python-client/issues/117))

<!-- Tell your future self why have you made these changes -->
**Why?**
It's a small but essential feature that people uses.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**