### PR TITLE
test(schedule): describe-first update_schedule

### DIFF
--- a/cadence/client.py
+++ b/cadence/client.py
@@ -3,6 +3,7 @@ import socket
 import uuid
 from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta
+from collections.abc import Callable
 from typing import Sequence, TypedDict, Unpack, Any, cast, Union
 
 from grpc import ChannelCredentials, Compression
@@ -673,25 +674,24 @@ class Client:
     async def update_schedule(
         self,
         schedule_id: str,
-        *,
-        spec: schedule_pb2.ScheduleSpec | None = None,
-        action: schedule_pb2.ScheduleAction | None = None,
-        policies: schedule_pb2.SchedulePolicies | None = None,
-        search_attributes: SearchAttributes | None = None,
+        updater: Callable[[DescribeScheduleResponse], None],
     ) -> None:
-        """Update the schedule configuration. Only supplied fields are applied."""
+        """Update a schedule using a read-modify-write pattern.
+
+        Fetches the current schedule state, passes it to ``updater`` for
+        modification, then sends the full updated state to the server.
+        """
+        current = await self.describe_schedule(schedule_id)
+        updater(current)
         req = UpdateScheduleRequest(
             domain=self.domain,
             schedule_id=schedule_id,
         )
-        if spec is not None:
-            req.spec.CopyFrom(spec)
-        if action is not None:
-            req.action.CopyFrom(action)
-        if policies is not None:
-            req.policies.CopyFrom(policies)
-        if search_attributes is not None:
-            req.search_attributes.CopyFrom(search_attributes)
+        req.spec.CopyFrom(current.spec)
+        req.action.CopyFrom(current.action)
+        req.policies.CopyFrom(current.policies)
+        if current.HasField("search_attributes"):
+            req.search_attributes.CopyFrom(current.search_attributes)
         await self._schedule_stub.UpdateSchedule(req)
 
     async def backfill_schedule(

--- a/tests/cadence/test_schedule.py
+++ b/tests/cadence/test_schedule.py
@@ -8,6 +8,7 @@ import grpc.aio
 import pytest
 
 from cadence.api.v1 import schedule_pb2
+from cadence.api.v1.common_pb2 import WorkflowType
 from cadence.api.v1.service_schedule_pb2 import (
     BackfillScheduleRequest,
     BackfillScheduleResponse,
@@ -45,6 +46,9 @@ class _FakeScheduleServicer(ScheduleAPIServicer):
         self.last_backfill: BackfillScheduleRequest | None = None
         self.list_pages: list[ListSchedulesResponse] = []
         self._list_call_count = 0
+        self.describe_response: DescribeScheduleResponse = DescribeScheduleResponse(
+            spec=schedule_pb2.ScheduleSpec(cron_expression="0 9 * * *"),
+        )
 
     async def CreateSchedule(self, request, context):
         self.last_create = request
@@ -52,9 +56,7 @@ class _FakeScheduleServicer(ScheduleAPIServicer):
 
     async def DescribeSchedule(self, request, context):
         self.last_describe = request
-        return DescribeScheduleResponse(
-            spec=schedule_pb2.ScheduleSpec(cron_expression="0 9 * * *"),
-        )
+        return self.describe_response
 
     async def PauseSchedule(self, request, context):
         self.last_pause = request
@@ -218,14 +220,42 @@ class TestDeleteSchedule:
 class TestUpdateSchedule:
     @pytest.mark.asyncio
     async def test_update_spec(self, client, servicer):
+        """update_schedule describes first then sends the full modified state."""
         new_spec = schedule_pb2.ScheduleSpec(cron_expression="0 12 * * *")
-        await client.update_schedule("sched-upd", spec=new_spec)
+        await client.update_schedule("sched-upd", lambda d: d.spec.CopyFrom(new_spec))
         assert servicer.last_update.spec.cron_expression == "0 12 * * *"
 
     @pytest.mark.asyncio
-    async def test_update_no_fields_sends_empty(self, client, servicer):
-        await client.update_schedule("sched-upd")
-        assert not servicer.last_update.HasField("spec")
+    async def test_update_preserves_unmodified_fields(self, client, servicer):
+        """Fields not touched by the updater callback are read from describe and preserved."""
+        original_action = schedule_pb2.ScheduleAction(
+            start_workflow=schedule_pb2.ScheduleAction.StartWorkflowAction(
+                workflow_type=WorkflowType(name="my-workflow"),
+            )
+        )
+        servicer.describe_response = DescribeScheduleResponse(
+            spec=schedule_pb2.ScheduleSpec(cron_expression="0 9 * * *"),
+            action=original_action,
+            policies=schedule_pb2.SchedulePolicies(
+                overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_SKIP_NEW,
+            ),
+        )
+        new_spec = schedule_pb2.ScheduleSpec(cron_expression="0 18 * * *")
+        await client.update_schedule("sched-upd", lambda d: d.spec.CopyFrom(new_spec))
+        assert servicer.last_update.spec.cron_expression == "0 18 * * *"
+        assert servicer.last_update.action == original_action
+        assert (
+            servicer.last_update.policies.overlap_policy
+            == schedule_pb2.SCHEDULE_OVERLAP_POLICY_SKIP_NEW
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_sends_full_state(self, client, servicer):
+        """UpdateScheduleRequest always contains spec, action, and policies from describe."""
+        await client.update_schedule("sched-upd", lambda d: None)
+        assert servicer.last_update.HasField("spec")
+        assert servicer.last_update.domain == "test-domain"
+        assert servicer.last_update.schedule_id == "sched-upd"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration_tests/test_schedule.py
+++ b/tests/integration_tests/test_schedule.py
@@ -4,6 +4,8 @@ Requires a running Cadence server. Run with:
     uv run pytest tests/integration_tests/test_schedule.py --integration-tests -v
 """
 
+import asyncio
+import time
 import uuid
 
 import pytest
@@ -87,12 +89,29 @@ async def test_pause_and_unpause(helper: CadenceHelper):
             )
 
             await client.pause_schedule(schedule_id, reason="integration-test")
-            paused_resp = await client.describe_schedule(schedule_id)
-            assert paused_resp.state.paused
+            # Signals are processed asynchronously; poll until the state propagates.
+            deadline = time.monotonic() + 10.0
+            paused_resp = None
+            while time.monotonic() < deadline:
+                paused_resp = await client.describe_schedule(schedule_id)
+                if paused_resp.state.paused:
+                    break
+                await asyncio.sleep(0.5)
+            assert paused_resp is not None and paused_resp.state.paused, (
+                f"schedule was not paused within timeout; last state: {paused_resp}"
+            )
 
             await client.unpause_schedule(schedule_id, reason="done")
-            resumed_resp = await client.describe_schedule(schedule_id)
-            assert not resumed_resp.state.paused
+            deadline = time.monotonic() + 10.0
+            resumed_resp = None
+            while time.monotonic() < deadline:
+                resumed_resp = await client.describe_schedule(schedule_id)
+                if not resumed_resp.state.paused:
+                    break
+                await asyncio.sleep(0.5)
+            assert resumed_resp is not None and not resumed_resp.state.paused, (
+                f"schedule was not unpaused within timeout; last state: {resumed_resp}"
+            )
         finally:
             await client.delete_schedule(schedule_id)
 
@@ -117,10 +136,18 @@ async def test_update_spec(helper: CadenceHelper):
             updated_spec = schedule_pb2.ScheduleSpec(cron_expression="0 18 * * *")
             await client.update_schedule(
                 schedule_id,
-                spec=updated_spec,
+                lambda d: d.spec.CopyFrom(updated_spec),
             )
 
-            resp = await client.describe_schedule(schedule_id)
+            # Signals are processed asynchronously; poll until the spec change propagates.
+            deadline = time.monotonic() + 10.0
+            resp = None
+            while time.monotonic() < deadline:
+                resp = await client.describe_schedule(schedule_id)
+                if resp.spec.cron_expression == updated_spec.cron_expression:
+                    break
+                await asyncio.sleep(0.5)
+            assert resp is not None, "describe_schedule never succeeded"
             _assert_describe_spec_and_action(resp, updated_spec, expected_action)
         finally:
             await client.delete_schedule(schedule_id)
@@ -142,7 +169,15 @@ async def test_list_schedules_contains_created(helper: CadenceHelper):
                 action=_make_schedule_action(),
             )
 
-            ids = [e.schedule_id async for e in client.list_schedules()]
-            assert schedule_id in ids
+            # Visibility is eventually consistent; poll until the entry appears.
+            deadline = time.monotonic() + 30.0
+            found = False
+            while time.monotonic() < deadline:
+                ids = [e.schedule_id async for e in client.list_schedules()]
+                if schedule_id in ids:
+                    found = True
+                    break
+                await asyncio.sleep(1.0)
+            assert found, f"schedule {schedule_id!r} not found in list within 30s"
         finally:
             await client.delete_schedule(schedule_id)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
update_schedule now uses a read-modify-write pattern (describe → callback → full state update). 

<!-- Tell your future self why have you made these changes -->
**Why?**
Server replaces the whole field on UpdateSchedule, so partial updates would zero out sub-fields the caller didn't intend to change.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests passing.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
N/A