### PR TITLE
feat(schedule): add lifecycle sample and update_schedule concurrency note

### DIFF
--- a/cadence/client.py
+++ b/cadence/client.py
@@ -680,6 +680,9 @@ class Client:
 
         Fetches the current schedule state, passes it to ``updater`` for
         modification, then sends the full updated state to the server.
+
+        Note: concurrent updates to the same schedule_id are not safe —
+        last write wins. The server API exposes no conflict token.
         """
         current = await self.describe_schedule(schedule_id)
         updater(current)

--- a/cadence/sample/schedule_example.py
+++ b/cadence/sample/schedule_example.py
@@ -1,0 +1,114 @@
+"""Example: full schedule lifecycle using the Cadence Python client.
+
+Demonstrates create, describe, pause/unpause, update, list, backfill, and delete.
+A worker is started alongside so that any workflows triggered by the schedule
+actually complete rather than time out.
+
+Run against local docker-compose:
+    docker-compose -f tests/integration_tests/docker-compose.yml up -d
+    uv run python cadence/sample/schedule_example.py
+
+Run against a remote server:
+    uv run python cadence/sample/schedule_example.py --target <host>:7833 --domain <domain>
+"""
+
+import argparse
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from cadence import Registry, workflow
+from cadence.api.v1 import common_pb2, schedule_pb2, tasklist_pb2
+from cadence.client import Client
+from cadence.worker import Worker
+
+TASK_LIST = "schedule-example-task-list"
+
+reg = Registry()
+
+
+@reg.workflow()
+class ExampleWorkflow:
+    """Short-lived workflow used as the schedule action target."""
+
+    @workflow.run
+    async def run(self) -> str:
+        return "done"
+
+
+async def main(target: str, domain: str) -> None:
+    async with Client(target=target, domain=domain) as client:
+        async with Worker(client, TASK_LIST, reg):
+            schedule_id = "example-daily-report"
+
+            # action defines which workflow the schedule will start on each fire
+            action = schedule_pb2.ScheduleAction(
+                start_workflow=schedule_pb2.ScheduleAction.StartWorkflowAction(
+                    workflow_type=common_pb2.WorkflowType(name="ExampleWorkflow"),
+                    task_list=tasklist_pb2.TaskList(name=TASK_LIST),
+                    execution_start_to_close_timeout=timedelta(seconds=30),
+                )
+            )
+
+            # Create: fires every day at 09:00 UTC
+            await client.create_schedule(
+                schedule_id,
+                spec=schedule_pb2.ScheduleSpec(cron_expression="0 9 * * *"),
+                action=action,
+            )
+            print(f"Created schedule: {schedule_id}")
+
+            # Describe: inspect current configuration and runtime info
+            desc = await client.describe_schedule(schedule_id)
+            print(f"  cron       : {desc.spec.cron_expression}")
+            print(f"  paused     : {desc.state.paused}")
+            print(f"  total_runs : {desc.info.total_runs}")
+
+            # Pause: stop new fires without deleting the schedule
+            await client.pause_schedule(schedule_id, reason="maintenance window")
+            print("Paused schedule")
+
+            # Unpause: resume firing
+            await client.unpause_schedule(
+                schedule_id,
+                reason="maintenance complete",
+                catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_SKIP,
+            )
+            print("Unpaused schedule")
+
+            # Update: change the cron expression using read-modify-write
+            await client.update_schedule(
+                schedule_id,
+                lambda d: d.spec.CopyFrom(
+                    schedule_pb2.ScheduleSpec(cron_expression="0 18 * * *")
+                ),
+            )
+            print("Updated cron to 18:00 UTC")
+
+            # List: iterate over all schedules in the domain
+            print("Schedules in domain:")
+            async for entry in client.list_schedules():
+                print(f"  {entry.schedule_id}  cron={entry.cron_expression}")
+
+            # Backfill: replay fires for a historical window
+            now = datetime.now(tz=timezone.utc)
+            await client.backfill_schedule(
+                schedule_id,
+                start_time=now - timedelta(hours=3),
+                end_time=now,
+                overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_CONCURRENT,
+            )
+            print("Triggered backfill for last 3 hours")
+
+            # Delete: remove the schedule (in-flight workflows are not affected)
+            await client.delete_schedule(schedule_id)
+            print(f"Deleted schedule: {schedule_id}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Schedule lifecycle example")
+    parser.add_argument(
+        "--target", default="localhost:7833", help="Cadence gRPC endpoint"
+    )
+    parser.add_argument("--domain", default="test-domain", help="Cadence domain")
+    args = parser.parse_args()
+    asyncio.run(main(args.target, args.domain))

--- a/cadence/sample/schedule_example.py
+++ b/cadence/sample/schedule_example.py
@@ -75,12 +75,10 @@ async def main(target: str, domain: str) -> None:
             )
             print("Unpaused schedule")
 
-            # Update: change the cron expression using read-modify-write
+            # Update: change only the cron field; other spec fields are preserved
             await client.update_schedule(
                 schedule_id,
-                lambda d: d.spec.CopyFrom(
-                    schedule_pb2.ScheduleSpec(cron_expression="0 18 * * *")
-                ),
+                lambda d: setattr(d.spec, "cron_expression", "0 18 * * *"),
             )
             print("Updated cron to 18:00 UTC")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ omit = [
     "*/test_*",
     "*/__pycache__/*",
     "*/venv/*",
+    "cadence/sample/*",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Summary

- **`cadence/sample/schedule_example.py`** : new sample demonstrating the full schedule lifecycle: create, describe, pause, unpause, update (read-modify-write), list, backfill, and delete. Includes an embedded worker so workflows triggered by the schedule actually complete.
- **`cadence/client.py`** : adds a concurrency warning to the `update_schedule` docstring: concurrent updates to the same schedule ID are not safe (last-write-wins, no conflict token exposed by the server API).

## Test plan

- [ ] `uv run pytest tests/cadence/ -q`
- [ ] Manual: start docker-compose, run `uv run python cadence/sample/schedule_example.py`, verify each step prints without error