### PR TITLE
feat(samples): add schedule_sample with full lifecycle demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ make integration-test
 make pr
 ```
 
+## Samples
+
+See [`samples/`](samples/README.md) for runnable examples covering schedules and more.
+
 ## License
 
 Apache 2.0 License, please see [LICENSE](LICENSE) for details.

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,37 @@
+# Cadence Python Client — Samples
+
+Runnable examples for the Cadence Python SDK.
+
+**Prerequisites for all samples:**
+
+1. A running Cadence server. The easiest way:
+   ```bash
+   cd tests/integration_tests
+   docker compose up -d
+   ```
+2. Install dependencies:
+   ```bash
+   uv sync --all-extras
+   ```
+
+---
+
+## Schedules
+
+> **Server prerequisite:** the target domain must have `worker.enableScheduler: true` in the server's dynamic config.
+
+### schedule_sample
+
+Full schedule lifecycle in one script: **create → describe → pause → unpause → backfill → update → list → delete**.
+
+**1. Start a worker** (keep running in one terminal):
+```bash
+uv run python samples/schedule_sample.py worker
+```
+
+**2. Run the demo** (in a second terminal):
+```bash
+uv run python samples/schedule_sample.py demo
+```
+
+Both subcommands accept `--target` (default `localhost:7833`) and `--domain` (default `samples-domain`).

--- a/samples/README.md
+++ b/samples/README.md
@@ -34,4 +34,4 @@ uv run python samples/schedule_sample.py worker
 uv run python samples/schedule_sample.py demo
 ```
 
-Both subcommands accept `--target` (default `localhost:7833`) and `--domain` (default `samples-domain`).
+Both subcommands accept `--target` (default `localhost:7833`) and `--domain` (default `test-domain`, which is pre-registered by the Docker Compose stack).

--- a/samples/schedule_sample.py
+++ b/samples/schedule_sample.py
@@ -25,8 +25,11 @@ import sys
 import uuid
 from datetime import datetime, timedelta, timezone
 
+from google.protobuf.duration import from_timedelta
+
 from cadence import Registry, workflow
 from cadence.client import Client
+from cadence.worker import Worker
 from cadence.api.v1 import common_pb2, schedule_pb2, tasklist_pb2
 
 TASK_LIST = "schedule-sample-tl"
@@ -50,8 +53,6 @@ class ScheduleSampleWorkflow:
 
 
 async def run_worker(args: argparse.Namespace) -> None:
-    from cadence.worker import Worker
-
     async with Client(domain=args.domain, target=args.target) as client:
         print(f"Worker running on task list {TASK_LIST!r} — Ctrl-C to stop")
         async with Worker(client, TASK_LIST, registry):
@@ -64,13 +65,14 @@ async def run_worker(args: argparse.Namespace) -> None:
 
 
 async def run_demo(args: argparse.Namespace) -> None:
-    client = Client(domain=args.domain, target=args.target)
     sid = f"schedule-sample-{uuid.uuid4().hex[:8]}"
 
     action = schedule_pb2.ScheduleAction(
         start_workflow=schedule_pb2.ScheduleAction.StartWorkflowAction(
             workflow_type=common_pb2.WorkflowType(name=WORKFLOW_TYPE),
             task_list=tasklist_pb2.TaskList(name=TASK_LIST),
+            execution_start_to_close_timeout=from_timedelta(timedelta(minutes=10)),
+            task_start_to_close_timeout=from_timedelta(timedelta(seconds=10)),
         )
     )
     spec = schedule_pb2.ScheduleSpec(cron_expression="* * * * *")
@@ -79,69 +81,68 @@ async def run_demo(args: argparse.Namespace) -> None:
         catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_SKIP,
     )
 
-    try:
-        # --- create ---
-        await client.create_schedule(sid, spec=spec, action=action, policies=policies)
-        print(f"Created  : {sid}")
-
-        # --- describe ---
-        desc = await client.describe_schedule(sid)
-        print(
-            f"Describe : cron={desc.spec.cron_expression!r}  paused={desc.state.paused}"
-        )
-
-        # --- pause ---
-        await client.pause_schedule(sid, reason="sample demo")
-        desc = await client.describe_schedule(sid)
-        print(
-            f"Paused   : paused={desc.state.paused}  reason={desc.state.pause_info.reason!r}"
-        )
-
-        # --- unpause ---
-        await client.unpause_schedule(
-            sid,
-            reason="resuming",
-            catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_SKIP,
-        )
-        desc = await client.describe_schedule(sid)
-        print(f"Unpaused : paused={desc.state.paused}")
-
-        # --- backfill (replays the per-minute schedule over the last 2 hours, ~120 triggers) ---
-        end = datetime.now(timezone.utc)
-        start = end - timedelta(hours=2)
-        await client.backfill_schedule(
-            sid,
-            start_time=start,
-            end_time=end,
-            overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_BUFFER,
-        )
-        print(f"Backfill : submitted 2-hour window ({start:%H:%M} → {end:%H:%M} UTC)")
-
-        # --- update (change cron) ---
-        def set_hourly(d: object) -> None:
-            d.spec.cron_expression = "0 * * * *"
-
-        await client.update_schedule(sid, set_hourly)
-        desc = await client.describe_schedule(sid)
-        print(f"Updated  : new cron={desc.spec.cron_expression!r}")
-
-        # --- list ---
-        print("List     : schedules in domain:")
-        async for entry in client.list_schedules():
-            marker = " ← this one" if entry.schedule_id == sid else ""
-            print(f"           {entry.schedule_id}{marker}")
-
-        # --- delete ---
-        await client.delete_schedule(sid)
-        print(f"Deleted  : {sid}")
-    except Exception:
+    async with Client(domain=args.domain, target=args.target) as client:
         try:
+            # --- create ---
+            await client.create_schedule(sid, spec=spec, action=action, policies=policies)
+            print(f"Created  : {sid}")
+
+            # --- describe ---
+            desc = await client.describe_schedule(sid)
+            print(
+                f"Describe : cron={desc.spec.cron_expression!r}  paused={desc.state.paused}"
+            )
+
+            # --- pause ---
+            await client.pause_schedule(sid, reason="sample demo")
+            desc = await client.describe_schedule(sid)
+            print(
+                f"Paused   : paused={desc.state.paused}  reason={desc.state.pause_info.reason!r}"
+            )
+
+            # --- unpause ---
+            await client.unpause_schedule(
+                sid,
+                reason="resuming",
+                catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_SKIP,
+            )
+            desc = await client.describe_schedule(sid)
+            print(f"Unpaused : paused={desc.state.paused}")
+
+            # --- backfill (replays the per-minute schedule over the last 2 hours, ~120 triggers) ---
+            end = datetime.now(timezone.utc)
+            start = end - timedelta(hours=2)
+            await client.backfill_schedule(
+                sid,
+                start_time=start,
+                end_time=end,
+                overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_BUFFER,
+            )
+            print(f"Backfill : submitted 2-hour window ({start:%H:%M} → {end:%H:%M} UTC)")
+
+            # --- update (change cron) ---
+            def set_hourly(d: object) -> None:
+                d.spec.cron_expression = "0 * * * *"
+
+            await client.update_schedule(sid, set_hourly)
+            desc = await client.describe_schedule(sid)
+            print(f"Updated  : new cron={desc.spec.cron_expression!r}")
+
+            # --- list ---
+            print("List     : schedules in domain:")
+            async for entry in client.list_schedules():
+                marker = " ← this one" if entry.schedule_id == sid else ""
+                print(f"           {entry.schedule_id}{marker}")
+
+            # --- delete ---
             await client.delete_schedule(sid)
-        except Exception as cleanup_err:
-            print(f"Cleanup failed for {sid}: {cleanup_err}")
-        raise
-    finally:
-        await client.close()
+            print(f"Deleted  : {sid}")
+        except Exception:
+            try:
+                await client.delete_schedule(sid)
+            except Exception as cleanup_err:
+                print(f"Cleanup failed for {sid}: {cleanup_err}")
+            raise
 
 
 # ---------------------------------------------------------------------------
@@ -154,7 +155,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--target", default="localhost:7833", help="Cadence frontend host:port"
     )
-    p.add_argument("--domain", default="samples-domain", help="Cadence domain")
+    p.add_argument("--domain", default="test-domain", help="Cadence domain")
 
     sub = p.add_subparsers(dest="cmd", required=True)
     sub.add_parser("worker", help="Run the workflow worker (keep running)")

--- a/samples/schedule_sample.py
+++ b/samples/schedule_sample.py
@@ -1,0 +1,179 @@
+"""Cadence Schedules sample.
+
+Walks through the full schedule lifecycle against a running Cadence server:
+
+    create → describe → pause → unpause → backfill → update → list → delete
+
+Prerequisites:
+    1. A running Cadence server with schedules enabled for the domain.
+       With the Docker Compose in tests/integration_tests/:
+           docker compose up -d
+    2. A worker running for the target task list. Start one in a separate
+       terminal before running this script:
+           uv run python samples/schedule_sample.py worker
+
+Usage (in a second terminal):
+    uv run python samples/schedule_sample.py demo
+
+The demo subcommand runs the full lifecycle and prints results.
+Both subcommands accept --target and --domain flags.
+"""
+
+import argparse
+import asyncio
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from cadence import Registry, workflow
+from cadence.client import Client
+from cadence.api.v1 import common_pb2, schedule_pb2, tasklist_pb2
+
+TASK_LIST = "schedule-sample-tl"
+WORKFLOW_TYPE = "ScheduleSampleWorkflow"
+
+registry = Registry()
+
+
+@registry.workflow()
+class ScheduleSampleWorkflow:
+    """No-op workflow started by the schedule on each trigger."""
+
+    @workflow.run
+    async def run(self) -> str:
+        return "ok"
+
+
+# ---------------------------------------------------------------------------
+# worker subcommand
+# ---------------------------------------------------------------------------
+
+
+async def run_worker(args: argparse.Namespace) -> None:
+    client = Client(domain=args.domain, target=args.target)
+    print(f"Worker running on task list {TASK_LIST!r} — Ctrl-C to stop")
+    from cadence.worker import Worker
+
+    async with Worker(client, TASK_LIST, registry):
+        await asyncio.Event().wait()
+
+
+# ---------------------------------------------------------------------------
+# demo subcommand
+# ---------------------------------------------------------------------------
+
+
+async def run_demo(args: argparse.Namespace) -> None:
+    client = Client(domain=args.domain, target=args.target)
+    sid = f"schedule-sample-{uuid.uuid4().hex[:8]}"
+
+    action = schedule_pb2.ScheduleAction(
+        start_workflow=schedule_pb2.ScheduleAction.StartWorkflowAction(
+            workflow_type=common_pb2.WorkflowType(name=WORKFLOW_TYPE),
+            task_list=tasklist_pb2.TaskList(name=TASK_LIST),
+        )
+    )
+    spec = schedule_pb2.ScheduleSpec(cron_expression="* * * * *")
+    policies = schedule_pb2.SchedulePolicies(
+        overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_SKIP_NEW,
+        catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_SKIP,
+    )
+
+    try:
+        # --- create ---
+        await client.create_schedule(sid, spec=spec, action=action, policies=policies)
+        print(f"Created  : {sid}")
+
+        # --- describe ---
+        desc = await client.describe_schedule(sid)
+        print(
+            f"Describe : cron={desc.spec.cron_expression!r}  paused={desc.state.paused}"
+        )
+
+        # --- pause ---
+        await client.pause_schedule(sid, reason="sample demo")
+        desc = await client.describe_schedule(sid)
+        print(
+            f"Paused   : paused={desc.state.paused}  reason={desc.state.pause_info.reason!r}"
+        )
+
+        # --- unpause ---
+        await client.unpause_schedule(
+            sid,
+            reason="resuming",
+            catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_SKIP,
+        )
+        desc = await client.describe_schedule(sid)
+        print(f"Unpaused : paused={desc.state.paused}")
+
+        # --- backfill (replays the per-minute schedule over the last 2 hours, ~120 triggers) ---
+        end = datetime.now(timezone.utc)
+        start = end - timedelta(hours=2)
+        await client.backfill_schedule(
+            sid,
+            start_time=start,
+            end_time=end,
+            overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_BUFFER,
+        )
+        print(f"Backfill : submitted 2-hour window ({start:%H:%M} → {end:%H:%M} UTC)")
+
+        # --- update (change cron) ---
+        def set_hourly(d: object) -> None:
+            d.spec.cron_expression = "0 * * * *"
+
+        await client.update_schedule(sid, set_hourly)
+        desc = await client.describe_schedule(sid)
+        print(f"Updated  : new cron={desc.spec.cron_expression!r}")
+
+        # --- list ---
+        print("List     : schedules in domain:")
+        async for entry in client.list_schedules():
+            marker = " ← this one" if entry.schedule_id == sid else ""
+            print(f"           {entry.schedule_id}{marker}")
+
+        # --- delete ---
+        await client.delete_schedule(sid)
+        print(f"Deleted  : {sid}")
+    except Exception:
+        try:
+            await client.delete_schedule(sid)
+        except Exception as cleanup_err:
+            print(f"Cleanup failed for {sid}: {cleanup_err}")
+        raise
+    finally:
+        await client.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Cadence Schedules sample")
+    p.add_argument(
+        "--target", default="localhost:7833", help="Cadence frontend host:port"
+    )
+    p.add_argument("--domain", default="samples-domain", help="Cadence domain")
+
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("worker", help="Run the workflow worker (keep running)")
+    sub.add_parser("demo", help="Run the schedule lifecycle demo")
+
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        if args.cmd == "worker":
+            asyncio.run(run_worker(args))
+        else:
+            asyncio.run(run_demo(args))
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/samples/schedule_sample.py
+++ b/samples/schedule_sample.py
@@ -50,12 +50,12 @@ class ScheduleSampleWorkflow:
 
 
 async def run_worker(args: argparse.Namespace) -> None:
-    client = Client(domain=args.domain, target=args.target)
-    print(f"Worker running on task list {TASK_LIST!r} — Ctrl-C to stop")
     from cadence.worker import Worker
 
-    async with Worker(client, TASK_LIST, registry):
-        await asyncio.Event().wait()
+    async with Client(domain=args.domain, target=args.target) as client:
+        print(f"Worker running on task list {TASK_LIST!r} — Ctrl-C to stop")
+        async with Worker(client, TASK_LIST, registry):
+            await asyncio.Event().wait()
 
 
 # ---------------------------------------------------------------------------

--- a/samples/schedule_sample.py
+++ b/samples/schedule_sample.py
@@ -84,7 +84,9 @@ async def run_demo(args: argparse.Namespace) -> None:
     async with Client(domain=args.domain, target=args.target) as client:
         try:
             # --- create ---
-            await client.create_schedule(sid, spec=spec, action=action, policies=policies)
+            await client.create_schedule(
+                sid, spec=spec, action=action, policies=policies
+            )
             print(f"Created  : {sid}")
 
             # --- describe ---
@@ -118,7 +120,9 @@ async def run_demo(args: argparse.Namespace) -> None:
                 end_time=end,
                 overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_BUFFER,
             )
-            print(f"Backfill : submitted 2-hour window ({start:%H:%M} → {end:%H:%M} UTC)")
+            print(
+                f"Backfill : submitted 2-hour window ({start:%H:%M} → {end:%H:%M} UTC)"
+            )
 
             # --- update (change cron) ---
             def set_hourly(d: object) -> None:


### PR DESCRIPTION
## Summary

- Adds `samples/schedule_sample.py` — a two-subcommand script (`worker` + `demo`) that walks through the complete Cadence Schedules lifecycle: create → describe → pause → unpause → backfill → update → list → delete
- Adds `samples/README.md` cataloguing the sample with run instructions
- Updates the main `README.md` with a short \"Samples\" pointer to `samples/README.md`
- The same sample has been ported to [cadence-samples#155](https://github.com/cadence-workflow/cadence-samples/pull/155) against the `v0.3.0` release

## Test plan

- [x] `uv run python samples/schedule_sample.py worker` — starts worker cleanly
- [x] `uv run python samples/schedule_sample.py demo` — runs full lifecycle, prints each step
- [x] `uv tool run ruff check samples/` — no lint errors
- [x] `uv tool run ruff format --check samples/` — no formatting issues