### PR TITLE
fix(test): correct dynamic config path in docker-compose

### DIFF
--- a/tests/integration_tests/docker-compose.yml
+++ b/tests/integration_tests/docker-compose.yml
@@ -33,8 +33,7 @@ services:
     environment:
       - "CASSANDRA_SEEDS=cassandra"
       - "STATSD_ENDPOINT=statsd:8125"
-      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
-      - "CADENCE_OVERRIDE_DYNAMIC_CONFIG=system.enableSchedules:true"
+      - "DYNAMIC_CONFIG_FILE_PATH=dynamicconfig/development.yaml"
     depends_on:
       - cassandra
       - statsd


### PR DESCRIPTION
## Summary

The `ubercadence/server` image places dynamic config files under `/etc/cadence/dynamicconfig/`, but the docker-compose `DYNAMIC_CONFIG_FILE_PATH` was set to `config/dynamicconfig/development.yaml`. That path does not exist in the image so the config file was silently ignored meaning `worker.enableScheduler: true` never loaded and all schedule API calls timed out with `DEADLINE_EXCEEDED`.

**Fix:** set the path to `dynamicconfig/development.yaml`, which resolves correctly to `/etc/cadence/dynamicconfig/development.yaml` inside the container.

Also removes the now-redundant `CADENCE_OVERRIDE_DYNAMIC_CONFIG=system.enableSchedules:true` line, the bundled `development.yaml` already sets `worker.enableScheduler: true`.

## How it was found

Running `samples/schedule_sample.py demo` against the Docker stack: `create_schedule` succeeded but `describe_schedule` always returned `DEADLINE_EXCEEDED`. Confirmed by running `find` inside the container the file was at `dynamicconfig/development.yaml`, not `config/dynamicconfig/development.yaml`. After the fix, the full demo ran end-to-end successfully.

## Test plan

- [ ] `docker compose up -d` → `uv run python samples/schedule_sample.py demo` completes all steps without error