### PR TITLE
chore(workflow): move out dataconverter from workflowInstance

### DIFF
--- a/cadence/_internal/workflow/workflow_engine.py
+++ b/cadence/_internal/workflow/workflow_engine.py
@@ -47,10 +47,11 @@ class WorkflowEngine:
     def __init__(self, info: WorkflowInfo, workflow_definition: WorkflowDefinition):
         self._event_loop = DeterministicEventLoop()
         self._decision_manager = DecisionManager(self._event_loop)
+        self._data_converter = info.data_converter
+        self._workflow_definition = workflow_definition
         self._workflow_instance = WorkflowInstance(
             self._event_loop,
             workflow_definition,
-            info.data_converter,
         )
         self._context = Context(info, self._decision_manager)
 
@@ -116,14 +117,20 @@ class WorkflowEngine:
             raise
 
     def _execute_query(self, query: WorkflowQuery) -> DecisionResult:
-        result_payload = self._workflow_instance.handle_query(
-            query.query_type, query.query_args
-        )
+        query_def = self._workflow_definition.queries.get(query.query_type)
+        if query_def is None:
+            raise ValueError(
+                f"Unknown query type '{query.query_type}'. "
+                f"Known types: {list(self._workflow_definition.queries.keys())}"
+            )
+
+        args = query_def.params_from_payload(self._data_converter, query.query_args)
+        result = self._workflow_instance.handle_query(query_def, args)
         return DecisionResult(
             decisions=[],
             query_result=WorkflowQueryResult(
                 result_type=QUERY_RESULT_TYPE_ANSWERED,
-                answer=result_payload,
+                answer=self._data_converter.to_data([result]),
             ),
         )
 
@@ -208,15 +215,15 @@ class WorkflowEngine:
                 self._decision_manager.handle_history_event(event)
 
     def _maybe_complete_workflow(self) -> Optional[Decision]:
+        if not self._workflow_instance.is_done():
+            return None
         try:
-            if result := self._workflow_instance.get_result():
-                return Decision(
-                    complete_workflow_execution_decision_attributes=CompleteWorkflowExecutionDecisionAttributes(
-                        result=result,
-                    )
+            result = self._workflow_instance.get_result()
+            return Decision(
+                complete_workflow_execution_decision_attributes=CompleteWorkflowExecutionDecisionAttributes(
+                    result=self._data_converter.to_data([result]),
                 )
-            else:
-                return None
+            )
         except (CancelledError, InvalidStateError, FatalDecisionError):
             raise
         except ContinueAsNewError as e:
@@ -225,7 +232,7 @@ class WorkflowEngine:
             attrs = ContinueAsNewWorkflowExecutionDecisionAttributes(
                 workflow_type=WorkflowType(name=e.workflow_type or info.workflow_type),
                 task_list=TaskList(name=e.task_list or info.workflow_task_list),
-                input=info.data_converter.to_data(list(e.workflow_args)),
+                input=self._data_converter.to_data(list(e.workflow_args)),
             )
             if e.execution_start_to_close_timeout is not None:
                 attrs.execution_start_to_close_timeout.FromTimedelta(
@@ -272,13 +279,34 @@ class WorkflowEngine:
     def _handle_started_input_event(
         self, attrs: WorkflowExecutionStartedEventAttributes, event: HistoryEvent
     ) -> None:
-        self._workflow_instance.start(attrs.input)
+        args = self._workflow_definition.run_signature.params_from_payload(
+            self._data_converter, attrs.input
+        )
+        self._workflow_instance.start(args)
 
     @_handle_input_event.register
     def _handle_signaled_input_event(
         self, attrs: WorkflowExecutionSignaledEventAttributes, event: HistoryEvent
     ) -> None:
-        self._workflow_instance.handle_signal(attrs.signal_name, attrs.input)
+        signal_def = self._workflow_definition.signals.get(attrs.signal_name)
+        if signal_def is None:
+            logger.warning(
+                "Received signal '%s' but no handler registered, dropping",
+                attrs.signal_name,
+            )
+            return
+
+        try:
+            args = signal_def.params_from_payload(self._data_converter, attrs.input)
+        except Exception as e:
+            logger.warning(
+                "Failed to decode payload for signal '%s', dropping: %s",
+                attrs.signal_name,
+                e,
+            )
+            return
+
+        self._workflow_instance.handle_signal(signal_def, args)
 
 
 def _failure_from_exception(e: Exception) -> Failure:

--- a/cadence/_internal/workflow/workflow_instance.py
+++ b/cadence/_internal/workflow/workflow_instance.py
@@ -6,9 +6,8 @@ from typing import Any, Optional, Callable, Awaitable
 from cadence._internal.workflow.deterministic_event_loop import (
     DeterministicEventLoop,
 )
-from cadence.api.v1.common_pb2 import Payload
-from cadence.data_converter import DataConverter
 from cadence.error import SignalFailure
+from cadence.query import QueryDefinition
 from cadence.signal import SignalDefinition
 from cadence.workflow import WorkflowDefinition
 
@@ -16,17 +15,22 @@ logger = logging.getLogger(__name__)
 
 
 class WorkflowInstance:
+    """Runs a workflow object on the deterministic event loop.
+
+    Operates entirely on decoded Python values: callers (the engine) own the
+    :class:`DataConverter` and are responsible for decoding inputs before they
+    reach this class and encoding results after they leave it.
+    """
+
     def __init__(
         self,
         loop: DeterministicEventLoop,
-        workflow_definition: WorkflowDefinition,
-        data_converter: DataConverter,
+        definition: WorkflowDefinition[Any],
     ):
         self._loop = loop
-        self._definition = workflow_definition
-        self._data_converter = data_converter
-        self._instance = workflow_definition.cls()  # construct a new workflow object
-        self._task: Optional[Task[Payload]] = None
+        self._definition = definition
+        self._instance = definition.cls()  # construct a new workflow object
+        self._task: Optional[Task[Any]] = None
         # Strong references to in-flight async signal handler tasks.
         self._signal_tasks: set[Task[Any]] = set()
         # Fail the decision task if a signal handler raises an exception.
@@ -35,21 +39,15 @@ class WorkflowInstance:
     def get_signal_failure(self) -> Optional[SignalFailure]:
         return self._signal_failure
 
-    def start(self, payload: Payload):
+    def start(self, args: list[Any]) -> None:
         if self._task is None:
             run_method = self._definition.get_run_method(self._instance)
-            # noinspection PyProtectedMember
-            workflow_input = self._definition._run_signature.params_from_payload(
-                self._data_converter, payload
-            )
-
-            self._task = self._loop.create_task(self._run(run_method, workflow_input))
+            self._task = self._loop.create_task(self._run(run_method, args))
 
     async def _run(
-        self, workflow_fn: Callable[[Any], Awaitable[Any]], args: list[Any]
-    ) -> Payload:
-        result = await workflow_fn(*args)
-        return self._data_converter.to_data([result])
+        self, workflow_fn: Callable[..., Awaitable[Any]], args: list[Any]
+    ) -> Any:
+        return await workflow_fn(*args)
 
     def run_until_yield(self):
         self._loop.run_until_yield()
@@ -57,35 +55,23 @@ class WorkflowInstance:
     def is_done(self) -> bool:
         return self._task is not None and self._task.done()
 
-    def get_result(self) -> Optional[Payload]:
+    def get_result(self) -> Any:
+        """Return the workflow's decoded result, or None if not yet done.
+
+        Re-raises any exception the workflow run method raised.
+        """
         if self._task is None or not self._task.done():
             return None
         return self._task.result()
 
-    def handle_signal(self, signal_name: str, payload: Payload) -> None:
-        signal_def = self._definition.signals.get(signal_name)
-        if signal_def is None:
-            logger.warning(
-                "Received signal '%s' but no handler registered, dropping",
-                signal_name,
-            )
-            return
-
-        try:
-            args = signal_def.params_from_payload(self._data_converter, payload)
-        except Exception as e:
-            logger.warning(
-                "Failed to decode payload for signal '%s', dropping: %s",
-                signal_name,
-                e,
-            )
-            return
-
+    def handle_signal(
+        self, signal_def: SignalDefinition[..., Any], args: list[Any]
+    ) -> None:
         task = self._loop.create_task(self._run_signal(signal_def, args))
         self._signal_tasks.add(task)
         task.add_done_callback(
             lambda completed_task: self._on_signal_task_done(
-                completed_task, signal_name
+                completed_task, signal_def.name
             )
         )
 
@@ -96,38 +82,33 @@ class WorkflowInstance:
         if inspect.iscoroutine(result):
             await result
 
-    def handle_query(self, query_type: str, query_args: Payload) -> Payload:
-        """Execute a query handler and return the serialized result.
+    def handle_query(
+        self, query_def: QueryDefinition[..., Any], args: list[Any]
+    ) -> Any:
+        """Execute a query handler and return its decoded result.
 
         The query runs synchronously against the current workflow state
         (after replay has caught up). It must not mutate state.
 
         Args:
-            query_type: The registered query type name.
-            query_args: Serialized query arguments.
+            query_def: The registered query definition.
+            args: Decoded query arguments.
 
         Returns:
-            Serialized query result as a Payload.
+            The query handler's result (not serialized).
 
         Raises:
-            ValueError: If the query type is not registered.
+            TypeError: If the query handler is asynchronous.
             Exception: If the query handler raises.
         """
-        query_def = self._definition.queries.get(query_type)
-        if query_def is None:
-            raise ValueError(
-                f"Unknown query type '{query_type}'. "
-                f"Known types: {list(self._definition.queries.keys())}"
-            )
-
-        args = query_def.params_from_payload(self._data_converter, query_args)
         result = query_def(self._instance, *args)
         if inspect.iscoroutine(result):
             result.close()
             raise TypeError(
-                f"Query handler '{query_type}' must be synchronous, got async function"
+                f"Query handler '{query_def.name}' must be synchronous, "
+                f"got async function"
             )
-        return self._data_converter.to_data([result])
+        return result
 
     def _on_signal_task_done(self, task: Task[Any], signal_name: str) -> None:
         self._signal_tasks.discard(task)

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -270,6 +270,11 @@ class WorkflowDefinition(Generic[C]):
         """Get the workflow run method from an instance of the workflow class."""
         return cast(Callable, getattr(instance, self._run_method_name))
 
+    @property
+    def run_signature(self) -> FnSignature:
+        """The signature of the workflow run method."""
+        return self._run_signature
+
     @staticmethod
     def wrap(cls: Type, opts: WorkflowDefinitionOptions) -> "WorkflowDefinition":
         """


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* workflowInstance no longer depends on data converter
* data conversion is done directly inside WorkflowEngine

<!-- Tell your future self why have you made these changes -->
**Why?**

Instead of coupled WE->WI->DC, it's more straightforward to do data conversion inside WE directly. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Existing Unit Test / Integration Test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**