### PR TITLE
feat: emit poller and worker metrics

### DIFF
--- a/cadence/metrics/metrics.py
+++ b/cadence/metrics/metrics.py
@@ -18,6 +18,8 @@ class MetricType(Enum):
 class MetricsEmitter(Protocol):
     """Protocol for metrics collection backends."""
 
+    def with_tags(self, tags: Dict[str, str]) -> "MetricsEmitter": ...
+
     def counter(
         self, key: str, n: int = 1, tags: Optional[Dict[str, str]] = None
     ) -> None:
@@ -37,8 +39,37 @@ class MetricsEmitter(Protocol):
         ...
 
 
+class _TaggedEmitter:
+    """MetricsEmitter wrapper that pre-bakes a fixed set of tags into every call."""
+
+    def __init__(self, base: MetricsEmitter, tags: Dict[str, str]) -> None:
+        self._base = base
+        self._tags = tags
+
+    def with_tags(self, tags: Dict[str, str]) -> MetricsEmitter:
+        return _TaggedEmitter(self._base, {**self._tags, **tags})
+
+    def counter(
+        self, key: str, n: int = 1, tags: Optional[Dict[str, str]] = None
+    ) -> None:
+        self._base.counter(key, n, tags={**self._tags, **(tags or {})})
+
+    def gauge(
+        self, key: str, value: float, tags: Optional[Dict[str, str]] = None
+    ) -> None:
+        self._base.gauge(key, value, tags={**self._tags, **(tags or {})})
+
+    def histogram(
+        self, key: str, value: float, tags: Optional[Dict[str, str]] = None
+    ) -> None:
+        self._base.histogram(key, value, tags={**self._tags, **(tags or {})})
+
+
 class NoOpMetricsEmitter:
     """No-op metrics emitter that discards all metrics."""
+
+    def with_tags(self, tags: Dict[str, str]) -> MetricsEmitter:
+        return self
 
     def counter(
         self, key: str, n: int = 1, tags: Optional[Dict[str, str]] = None

--- a/cadence/metrics/prometheus.py
+++ b/cadence/metrics/prometheus.py
@@ -97,6 +97,8 @@ class PrometheusMetrics(MetricsEmitter):
 
         if metric_name not in self._histograms:
             label_names = list(self._merge_labels(labels).keys()) if labels else []
+            # Current histogram uses the prometheus_client default buckets; aligning
+            # bucket definitions with the Go SDK is planned for a later PR.
             self._histograms[metric_name] = Histogram(
                 metric_name,
                 f"Histogram metric for {name}",

--- a/cadence/metrics/prometheus.py
+++ b/cadence/metrics/prometheus.py
@@ -13,7 +13,7 @@ from prometheus_client import (  # type: ignore[import-not-found]
     generate_latest,
 )
 
-from .metrics import MetricsEmitter
+from .metrics import MetricsEmitter, _TaggedEmitter
 
 
 logger = logging.getLogger(__name__)
@@ -108,6 +108,9 @@ class PrometheusMetrics(MetricsEmitter):
             logger.debug(f"Created histogram metric: {metric_name}")
 
         return self._histograms[metric_name]
+
+    def with_tags(self, tags: Dict[str, str]) -> "MetricsEmitter":
+        return _TaggedEmitter(self, tags)
 
     def counter(
         self, key: str, n: int = 1, tags: Optional[Dict[str, str]] = None

--- a/cadence/worker/_activity.py
+++ b/cadence/worker/_activity.py
@@ -1,13 +1,31 @@
 import asyncio
+import time
 from typing import Optional
 
 from cadence._internal.activity import ActivityExecutor
+from cadence._internal.rpc.retry import RETRYABLE_CODES
 from cadence.api.v1.service_worker_pb2 import (
     PollForActivityTaskResponse,
     PollForActivityTaskRequest,
 )
 from cadence.api.v1.tasklist_pb2 import TaskList, TaskListKind
 from cadence.client import Client
+from cadence.error import CadenceRpcError
+from cadence.metrics import MetricsEmitter, NoOpMetricsEmitter
+from cadence.metrics.constants import (
+    ACTIVITY_POLL_COUNTER,
+    ACTIVITY_POLL_FAILED_COUNTER,
+    ACTIVITY_POLL_LATENCY,
+    ACTIVITY_POLL_NO_TASK_COUNTER,
+    ACTIVITY_POLL_SUCCEED_COUNTER,
+    ACTIVITY_POLL_TRANSIENT_FAILED_COUNTER,
+    ACTIVITY_SCHEDULED_TO_START_LATENCY,
+    POLLER_START_COUNTER,
+    TAG_DOMAIN,
+    TAG_TASK_LIST,
+    WORKER_PANIC_COUNTER,
+    WORKER_START_COUNTER,
+)
 from cadence.worker._registry import Registry
 from cadence.worker._types import WorkerOptions, _LONG_POLL_TIMEOUT
 from cadence.worker._poller import Poller
@@ -20,6 +38,11 @@ class ActivityWorker:
         self._client = client
         self._task_list = task_list
         self._identity = options["identity"]
+        self._metrics_emitter: MetricsEmitter = options.get(  # type: ignore[attr-defined]
+            "metrics_emitter", NoOpMetricsEmitter()
+        )
+        self._tags = {TAG_DOMAIN: client.domain, TAG_TASK_LIST: task_list}
+        self._num_pollers = options["activity_task_pollers"]
         max_concurrent = options["max_concurrent_activity_execution_size"]
         permits = asyncio.Semaphore(max_concurrent)
         self._executor = ActivityExecutor(
@@ -31,30 +54,61 @@ class ActivityWorker:
             options["metrics_emitter"],
         )
         self._poller = Poller[PollForActivityTaskResponse](
-            options["activity_task_pollers"], permits, self._poll, self._execute
+            self._num_pollers, permits, self._poll, self._execute
         )
         # TODO: Local dispatch, local activities, actually running activities, etc
 
     async def run(self) -> None:
-        await self._poller.run()
+        self._metrics_emitter.counter(WORKER_START_COUNTER, tags=self._tags)
+        self._metrics_emitter.counter(POLLER_START_COUNTER, self._num_pollers, tags=self._tags)
+        try:
+            await self._poller.run()
+        except Exception:
+            self._metrics_emitter.counter(WORKER_PANIC_COUNTER, tags=self._tags)
+            raise
 
     async def _poll(self) -> Optional[PollForActivityTaskResponse]:
-        task: PollForActivityTaskResponse = (
-            await self._client.worker_stub.PollForActivityTask(
-                PollForActivityTaskRequest(
-                    domain=self._client.domain,
-                    task_list=TaskList(
-                        name=self._task_list, kind=TaskListKind.TASK_LIST_KIND_NORMAL
+        self._metrics_emitter.counter(ACTIVITY_POLL_COUNTER, tags=self._tags)
+        start = time.monotonic()
+        try:
+            task: PollForActivityTaskResponse = (
+                await self._client.worker_stub.PollForActivityTask(
+                    PollForActivityTaskRequest(
+                        domain=self._client.domain,
+                        task_list=TaskList(
+                            name=self._task_list, kind=TaskListKind.TASK_LIST_KIND_NORMAL
+                        ),
+                        identity=self._identity,
                     ),
-                    identity=self._identity,
-                ),
-                timeout=_LONG_POLL_TIMEOUT,
+                    timeout=_LONG_POLL_TIMEOUT,
+                )
             )
-        )
+        except CadenceRpcError as e:
+            elapsed = time.monotonic() - start
+            self._metrics_emitter.histogram(ACTIVITY_POLL_LATENCY, elapsed, tags=self._tags)
+            if e.code in RETRYABLE_CODES:
+                self._metrics_emitter.counter(
+                    ACTIVITY_POLL_TRANSIENT_FAILED_COUNTER, tags=self._tags
+                )
+            else:
+                self._metrics_emitter.counter(ACTIVITY_POLL_FAILED_COUNTER, tags=self._tags)
+            raise
+
+        elapsed = time.monotonic() - start
+        self._metrics_emitter.histogram(ACTIVITY_POLL_LATENCY, elapsed, tags=self._tags)
 
         if task.task_token:
+            self._metrics_emitter.counter(ACTIVITY_POLL_SUCCEED_COUNTER, tags=self._tags)
+            if task.scheduled_time.seconds and task.started_time.seconds:
+                scheduled_to_start = (
+                    task.started_time.seconds + task.started_time.nanos / 1e9
+                ) - (task.scheduled_time.seconds + task.scheduled_time.nanos / 1e9)
+                self._metrics_emitter.histogram(
+                    ACTIVITY_SCHEDULED_TO_START_LATENCY, scheduled_to_start, tags=self._tags
+                )
             return task
         else:
+            self._metrics_emitter.counter(ACTIVITY_POLL_NO_TASK_COUNTER, tags=self._tags)
             return None
 
     async def _execute(self, task: PollForActivityTaskResponse) -> None:

--- a/cadence/worker/_activity.py
+++ b/cadence/worker/_activity.py
@@ -8,7 +8,6 @@ from cadence.api.v1.service_worker_pb2 import (
 )
 from cadence.api.v1.tasklist_pb2 import TaskList, TaskListKind
 from cadence.client import Client
-from cadence.error import CadenceRpcError
 from cadence.metrics import MetricsEmitter
 from cadence.metrics.constants import (
     ACTIVITY_POLL_COUNTER,
@@ -72,8 +71,7 @@ class ActivityWorker:
         )
 
     async def _poll(self) -> Optional[PollForActivityTaskResponse]:
-        start = self._poll_metrics.start_poll()
-        try:
+        async with self._poll_metrics.track() as start:
             task: PollForActivityTaskResponse = (
                 await self._client.worker_stub.PollForActivityTask(
                     PollForActivityTaskRequest(
@@ -87,11 +85,8 @@ class ActivityWorker:
                     timeout=_LONG_POLL_TIMEOUT,
                 )
             )
-        except CadenceRpcError as e:
-            self._poll_metrics.record_failure(start, e)
-            raise
-        self._poll_metrics.record_result(start, task)
-        return task if task.task_token else None
+            self._poll_metrics.record_result(start, task)
+            return task if task.task_token else None
 
     async def _execute(self, task: PollForActivityTaskResponse) -> None:
         await self._executor.execute(task)

--- a/cadence/worker/_activity.py
+++ b/cadence/worker/_activity.py
@@ -62,13 +62,18 @@ class ActivityWorker:
             options["metrics_emitter"],
         )
         self._poller = Poller[PollForActivityTaskResponse](
-            self._num_pollers, permits, self._poll, self._execute
+            self._num_pollers,
+            permits,
+            self._poll,
+            self._execute,
+            on_start=lambda num_pollers: self._tagged_emitter.counter(
+                POLLER_START_COUNTER, num_pollers
+            ),
         )
         # TODO: Local dispatch, local activities, actually running activities, etc
 
     async def run(self) -> None:
         self._tagged_emitter.counter(WORKER_START_COUNTER)
-        self._tagged_emitter.counter(POLLER_START_COUNTER, self._num_pollers)
         try:
             await self._poller.run()
         except Exception:

--- a/cadence/worker/_activity.py
+++ b/cadence/worker/_activity.py
@@ -1,9 +1,7 @@
 import asyncio
-import time
 from typing import Optional
 
 from cadence._internal.activity import ActivityExecutor
-from cadence._internal.rpc.retry import RETRYABLE_CODES
 from cadence.api.v1.service_worker_pb2 import (
     PollForActivityTaskResponse,
     PollForActivityTaskRequest,
@@ -11,7 +9,7 @@ from cadence.api.v1.service_worker_pb2 import (
 from cadence.api.v1.tasklist_pb2 import TaskList, TaskListKind
 from cadence.client import Client
 from cadence.error import CadenceRpcError
-from cadence.metrics import MetricsEmitter, NoOpMetricsEmitter
+from cadence.metrics import MetricsEmitter
 from cadence.metrics.constants import (
     ACTIVITY_POLL_COUNTER,
     ACTIVITY_POLL_FAILED_COUNTER,
@@ -20,15 +18,13 @@ from cadence.metrics.constants import (
     ACTIVITY_POLL_SUCCEED_COUNTER,
     ACTIVITY_POLL_TRANSIENT_FAILED_COUNTER,
     ACTIVITY_SCHEDULED_TO_START_LATENCY,
-    POLLER_START_COUNTER,
     TAG_DOMAIN,
     TAG_TASK_LIST,
-    WORKER_PANIC_COUNTER,
-    WORKER_START_COUNTER,
 )
+from cadence.worker._poll_metrics import PollMetrics, run_with_lifecycle_metrics
+from cadence.worker._poller import Poller
 from cadence.worker._registry import Registry
 from cadence.worker._types import WorkerOptions, _LONG_POLL_TIMEOUT
-from cadence.worker._poller import Poller
 
 
 class ActivityWorker:
@@ -38,11 +34,20 @@ class ActivityWorker:
         self._client = client
         self._task_list = task_list
         self._identity = options["identity"]
-        self._metrics_emitter: MetricsEmitter = options.get(  # type: ignore[attr-defined]
-            "metrics_emitter", NoOpMetricsEmitter()
-        )
+        self._metrics_emitter: MetricsEmitter = options["metrics_emitter"]
         self._tags = {TAG_DOMAIN: client.domain, TAG_TASK_LIST: task_list}
         self._num_pollers = options["activity_task_pollers"]
+        self._poll_metrics = PollMetrics(
+            emitter=self._metrics_emitter,
+            tags=self._tags,
+            poll=ACTIVITY_POLL_COUNTER,
+            latency=ACTIVITY_POLL_LATENCY,
+            succeed=ACTIVITY_POLL_SUCCEED_COUNTER,
+            no_task=ACTIVITY_POLL_NO_TASK_COUNTER,
+            failed=ACTIVITY_POLL_FAILED_COUNTER,
+            transient_failed=ACTIVITY_POLL_TRANSIENT_FAILED_COUNTER,
+            scheduled_to_start=ACTIVITY_SCHEDULED_TO_START_LATENCY,
+        )
         max_concurrent = options["max_concurrent_activity_execution_size"]
         permits = asyncio.Semaphore(max_concurrent)
         self._executor = ActivityExecutor(
@@ -59,19 +64,15 @@ class ActivityWorker:
         # TODO: Local dispatch, local activities, actually running activities, etc
 
     async def run(self) -> None:
-        self._metrics_emitter.counter(WORKER_START_COUNTER, tags=self._tags)
-        self._metrics_emitter.counter(
-            POLLER_START_COUNTER, self._num_pollers, tags=self._tags
+        await run_with_lifecycle_metrics(
+            self._metrics_emitter,
+            self._poller,
+            num_pollers=self._num_pollers,
+            tags=self._tags,
         )
-        try:
-            await self._poller.run()
-        except Exception:
-            self._metrics_emitter.counter(WORKER_PANIC_COUNTER, tags=self._tags)
-            raise
 
     async def _poll(self) -> Optional[PollForActivityTaskResponse]:
-        self._metrics_emitter.counter(ACTIVITY_POLL_COUNTER, tags=self._tags)
-        start = time.monotonic()
+        start = self._poll_metrics.start_poll()
         try:
             task: PollForActivityTaskResponse = (
                 await self._client.worker_stub.PollForActivityTask(
@@ -87,42 +88,10 @@ class ActivityWorker:
                 )
             )
         except CadenceRpcError as e:
-            elapsed = time.monotonic() - start
-            self._metrics_emitter.histogram(
-                ACTIVITY_POLL_LATENCY, elapsed, tags=self._tags
-            )
-            if e.code in RETRYABLE_CODES:
-                self._metrics_emitter.counter(
-                    ACTIVITY_POLL_TRANSIENT_FAILED_COUNTER, tags=self._tags
-                )
-            else:
-                self._metrics_emitter.counter(
-                    ACTIVITY_POLL_FAILED_COUNTER, tags=self._tags
-                )
+            self._poll_metrics.record_failure(start, e)
             raise
-
-        elapsed = time.monotonic() - start
-        self._metrics_emitter.histogram(ACTIVITY_POLL_LATENCY, elapsed, tags=self._tags)
-
-        if task.task_token:
-            self._metrics_emitter.counter(
-                ACTIVITY_POLL_SUCCEED_COUNTER, tags=self._tags
-            )
-            if task.scheduled_time.seconds and task.started_time.seconds:
-                scheduled_to_start = (
-                    task.started_time.seconds + task.started_time.nanos / 1e9
-                ) - (task.scheduled_time.seconds + task.scheduled_time.nanos / 1e9)
-                self._metrics_emitter.histogram(
-                    ACTIVITY_SCHEDULED_TO_START_LATENCY,
-                    scheduled_to_start,
-                    tags=self._tags,
-                )
-            return task
-        else:
-            self._metrics_emitter.counter(
-                ACTIVITY_POLL_NO_TASK_COUNTER, tags=self._tags
-            )
-            return None
+        self._poll_metrics.record_result(start, task)
+        return task if task.task_token else None
 
     async def _execute(self, task: PollForActivityTaskResponse) -> None:
         await self._executor.execute(task)

--- a/cadence/worker/_activity.py
+++ b/cadence/worker/_activity.py
@@ -20,6 +20,7 @@ from cadence.metrics.constants import (
     POLLER_START_COUNTER,
     TAG_DOMAIN,
     TAG_TASK_LIST,
+    WORKER_PANIC_COUNTER,
     WORKER_START_COUNTER,
 )
 from cadence.worker._poll_metrics import PollMetrics
@@ -68,7 +69,11 @@ class ActivityWorker:
     async def run(self) -> None:
         self._tagged_emitter.counter(WORKER_START_COUNTER)
         self._tagged_emitter.counter(POLLER_START_COUNTER, self._num_pollers)
-        await self._poller.run()
+        try:
+            await self._poller.run()
+        except Exception:
+            self._tagged_emitter.counter(WORKER_PANIC_COUNTER)
+            raise
 
     async def _poll(self) -> Optional[PollForActivityTaskResponse]:
         async with self._poll_metrics.track() as start:

--- a/cadence/worker/_activity.py
+++ b/cadence/worker/_activity.py
@@ -60,7 +60,9 @@ class ActivityWorker:
 
     async def run(self) -> None:
         self._metrics_emitter.counter(WORKER_START_COUNTER, tags=self._tags)
-        self._metrics_emitter.counter(POLLER_START_COUNTER, self._num_pollers, tags=self._tags)
+        self._metrics_emitter.counter(
+            POLLER_START_COUNTER, self._num_pollers, tags=self._tags
+        )
         try:
             await self._poller.run()
         except Exception:
@@ -76,7 +78,8 @@ class ActivityWorker:
                     PollForActivityTaskRequest(
                         domain=self._client.domain,
                         task_list=TaskList(
-                            name=self._task_list, kind=TaskListKind.TASK_LIST_KIND_NORMAL
+                            name=self._task_list,
+                            kind=TaskListKind.TASK_LIST_KIND_NORMAL,
                         ),
                         identity=self._identity,
                     ),
@@ -85,30 +88,40 @@ class ActivityWorker:
             )
         except CadenceRpcError as e:
             elapsed = time.monotonic() - start
-            self._metrics_emitter.histogram(ACTIVITY_POLL_LATENCY, elapsed, tags=self._tags)
+            self._metrics_emitter.histogram(
+                ACTIVITY_POLL_LATENCY, elapsed, tags=self._tags
+            )
             if e.code in RETRYABLE_CODES:
                 self._metrics_emitter.counter(
                     ACTIVITY_POLL_TRANSIENT_FAILED_COUNTER, tags=self._tags
                 )
             else:
-                self._metrics_emitter.counter(ACTIVITY_POLL_FAILED_COUNTER, tags=self._tags)
+                self._metrics_emitter.counter(
+                    ACTIVITY_POLL_FAILED_COUNTER, tags=self._tags
+                )
             raise
 
         elapsed = time.monotonic() - start
         self._metrics_emitter.histogram(ACTIVITY_POLL_LATENCY, elapsed, tags=self._tags)
 
         if task.task_token:
-            self._metrics_emitter.counter(ACTIVITY_POLL_SUCCEED_COUNTER, tags=self._tags)
+            self._metrics_emitter.counter(
+                ACTIVITY_POLL_SUCCEED_COUNTER, tags=self._tags
+            )
             if task.scheduled_time.seconds and task.started_time.seconds:
                 scheduled_to_start = (
                     task.started_time.seconds + task.started_time.nanos / 1e9
                 ) - (task.scheduled_time.seconds + task.scheduled_time.nanos / 1e9)
                 self._metrics_emitter.histogram(
-                    ACTIVITY_SCHEDULED_TO_START_LATENCY, scheduled_to_start, tags=self._tags
+                    ACTIVITY_SCHEDULED_TO_START_LATENCY,
+                    scheduled_to_start,
+                    tags=self._tags,
                 )
             return task
         else:
-            self._metrics_emitter.counter(ACTIVITY_POLL_NO_TASK_COUNTER, tags=self._tags)
+            self._metrics_emitter.counter(
+                ACTIVITY_POLL_NO_TASK_COUNTER, tags=self._tags
+            )
             return None
 
     async def _execute(self, task: PollForActivityTaskResponse) -> None:

--- a/cadence/worker/_activity.py
+++ b/cadence/worker/_activity.py
@@ -17,10 +17,12 @@ from cadence.metrics.constants import (
     ACTIVITY_POLL_SUCCEED_COUNTER,
     ACTIVITY_POLL_TRANSIENT_FAILED_COUNTER,
     ACTIVITY_SCHEDULED_TO_START_LATENCY,
+    POLLER_START_COUNTER,
     TAG_DOMAIN,
     TAG_TASK_LIST,
+    WORKER_START_COUNTER,
 )
-from cadence.worker._poll_metrics import PollMetrics, run_with_lifecycle_metrics
+from cadence.worker._poll_metrics import PollMetrics
 from cadence.worker._poller import Poller
 from cadence.worker._registry import Registry
 from cadence.worker._types import WorkerOptions, _LONG_POLL_TIMEOUT
@@ -34,11 +36,12 @@ class ActivityWorker:
         self._task_list = task_list
         self._identity = options["identity"]
         self._metrics_emitter: MetricsEmitter = options["metrics_emitter"]
-        self._tags = {TAG_DOMAIN: client.domain, TAG_TASK_LIST: task_list}
+        self._tagged_emitter = self._metrics_emitter.with_tags(
+            {TAG_DOMAIN: client.domain, TAG_TASK_LIST: task_list}
+        )
         self._num_pollers = options["activity_task_pollers"]
         self._poll_metrics = PollMetrics(
-            emitter=self._metrics_emitter,
-            tags=self._tags,
+            emitter=self._tagged_emitter,
             poll=ACTIVITY_POLL_COUNTER,
             latency=ACTIVITY_POLL_LATENCY,
             succeed=ACTIVITY_POLL_SUCCEED_COUNTER,
@@ -63,12 +66,9 @@ class ActivityWorker:
         # TODO: Local dispatch, local activities, actually running activities, etc
 
     async def run(self) -> None:
-        await run_with_lifecycle_metrics(
-            self._metrics_emitter,
-            self._poller,
-            num_pollers=self._num_pollers,
-            tags=self._tags,
-        )
+        self._tagged_emitter.counter(WORKER_START_COUNTER)
+        self._tagged_emitter.counter(POLLER_START_COUNTER, self._num_pollers)
+        await self._poller.run()
 
     async def _poll(self) -> Optional[PollForActivityTaskResponse]:
         async with self._poll_metrics.track() as start:

--- a/cadence/worker/_decision.py
+++ b/cadence/worker/_decision.py
@@ -63,13 +63,18 @@ class DecisionWorker:
             client, task_list, registry, executor=executor, **options
         )
         self._poller = Poller[PollForDecisionTaskResponse](
-            self._num_pollers, permits, self._poll, self._execute
+            self._num_pollers,
+            permits,
+            self._poll,
+            self._execute,
+            on_start=lambda num_pollers: self._tagged_emitter.counter(
+                POLLER_START_COUNTER, num_pollers
+            ),
         )
         # TODO: Sticky poller, actually running workflows, etc.
 
     async def run(self) -> None:
         self._tagged_emitter.counter(WORKER_START_COUNTER)
-        self._tagged_emitter.counter(POLLER_START_COUNTER, self._num_pollers)
         try:
             await self._poller.run()
         except Exception:

--- a/cadence/worker/_decision.py
+++ b/cadence/worker/_decision.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
@@ -10,7 +9,7 @@ from cadence.api.v1.service_worker_pb2 import (
 from cadence.api.v1.tasklist_pb2 import TaskList, TaskListKind
 from cadence.client import Client
 from cadence.error import CadenceRpcError
-from cadence.metrics import MetricsEmitter, NoOpMetricsEmitter
+from cadence.metrics import MetricsEmitter
 from cadence.metrics.constants import (
     DECISION_POLL_COUNTER,
     DECISION_POLL_FAILED_COUNTER,
@@ -19,14 +18,11 @@ from cadence.metrics.constants import (
     DECISION_POLL_SUCCEED_COUNTER,
     DECISION_POLL_TRANSIENT_FAILED_COUNTER,
     DECISION_SCHEDULED_TO_START_LATENCY,
-    POLLER_START_COUNTER,
     TAG_DOMAIN,
     TAG_TASK_LIST,
-    WORKER_PANIC_COUNTER,
-    WORKER_START_COUNTER,
 )
-from cadence._internal.rpc.retry import RETRYABLE_CODES
 from cadence.worker._decision_task_handler import DecisionTaskHandler
+from cadence.worker._poll_metrics import PollMetrics, run_with_lifecycle_metrics
 from cadence.worker._poller import Poller
 from cadence.worker._registry import Registry
 from cadence.worker._types import _LONG_POLL_TIMEOUT, WorkerOptions
@@ -40,11 +36,20 @@ class DecisionWorker:
         self._task_list = task_list
         self._registry = registry
         self._identity = options["identity"]
-        self._metrics_emitter: MetricsEmitter = options.get(  # type: ignore[attr-defined]
-            "metrics_emitter", NoOpMetricsEmitter()
-        )
+        self._metrics_emitter: MetricsEmitter = options["metrics_emitter"]
         self._tags = {TAG_DOMAIN: client.domain, TAG_TASK_LIST: task_list}
         self._num_pollers = options["decision_task_pollers"]
+        self._poll_metrics = PollMetrics(
+            emitter=self._metrics_emitter,
+            tags=self._tags,
+            poll=DECISION_POLL_COUNTER,
+            latency=DECISION_POLL_LATENCY,
+            succeed=DECISION_POLL_SUCCEED_COUNTER,
+            no_task=DECISION_POLL_NO_TASK_COUNTER,
+            failed=DECISION_POLL_FAILED_COUNTER,
+            transient_failed=DECISION_POLL_TRANSIENT_FAILED_COUNTER,
+            scheduled_to_start=DECISION_SCHEDULED_TO_START_LATENCY,
+        )
         permits = asyncio.Semaphore(
             options["max_concurrent_decision_task_execution_size"]
         )
@@ -60,19 +65,15 @@ class DecisionWorker:
         # TODO: Sticky poller, actually running workflows, etc.
 
     async def run(self) -> None:
-        self._metrics_emitter.counter(WORKER_START_COUNTER, tags=self._tags)
-        self._metrics_emitter.counter(
-            POLLER_START_COUNTER, self._num_pollers, tags=self._tags
+        await run_with_lifecycle_metrics(
+            self._metrics_emitter,
+            self._poller,
+            num_pollers=self._num_pollers,
+            tags=self._tags,
         )
-        try:
-            await self._poller.run()
-        except Exception:
-            self._metrics_emitter.counter(WORKER_PANIC_COUNTER, tags=self._tags)
-            raise
 
     async def _poll(self) -> Optional[PollForDecisionTaskResponse]:
-        self._metrics_emitter.counter(DECISION_POLL_COUNTER, tags=self._tags)
-        start = time.monotonic()
+        start = self._poll_metrics.start_poll()
         try:
             task: PollForDecisionTaskResponse = (
                 await self._client.worker_stub.PollForDecisionTask(
@@ -88,42 +89,10 @@ class DecisionWorker:
                 )
             )
         except CadenceRpcError as e:
-            elapsed = time.monotonic() - start
-            self._metrics_emitter.histogram(
-                DECISION_POLL_LATENCY, elapsed, tags=self._tags
-            )
-            if e.code in RETRYABLE_CODES:
-                self._metrics_emitter.counter(
-                    DECISION_POLL_TRANSIENT_FAILED_COUNTER, tags=self._tags
-                )
-            else:
-                self._metrics_emitter.counter(
-                    DECISION_POLL_FAILED_COUNTER, tags=self._tags
-                )
+            self._poll_metrics.record_failure(start, e)
             raise
-
-        elapsed = time.monotonic() - start
-        self._metrics_emitter.histogram(DECISION_POLL_LATENCY, elapsed, tags=self._tags)
-
-        if task and task.task_token:
-            self._metrics_emitter.counter(
-                DECISION_POLL_SUCCEED_COUNTER, tags=self._tags
-            )
-            if task.scheduled_time.seconds and task.started_time.seconds:
-                scheduled_to_start = (
-                    task.started_time.seconds + task.started_time.nanos / 1e9
-                ) - (task.scheduled_time.seconds + task.scheduled_time.nanos / 1e9)
-                self._metrics_emitter.histogram(
-                    DECISION_SCHEDULED_TO_START_LATENCY,
-                    scheduled_to_start,
-                    tags=self._tags,
-                )
-            return task
-        else:
-            self._metrics_emitter.counter(
-                DECISION_POLL_NO_TASK_COUNTER, tags=self._tags
-            )
-            return None
+        self._poll_metrics.record_result(start, task)
+        return task if (task and task.task_token) else None
 
     async def _execute(self, task: PollForDecisionTaskResponse) -> None:
         await self._decision_handler.handle_task(task)

--- a/cadence/worker/_decision.py
+++ b/cadence/worker/_decision.py
@@ -61,7 +61,9 @@ class DecisionWorker:
 
     async def run(self) -> None:
         self._metrics_emitter.counter(WORKER_START_COUNTER, tags=self._tags)
-        self._metrics_emitter.counter(POLLER_START_COUNTER, self._num_pollers, tags=self._tags)
+        self._metrics_emitter.counter(
+            POLLER_START_COUNTER, self._num_pollers, tags=self._tags
+        )
         try:
             await self._poller.run()
         except Exception:
@@ -77,7 +79,8 @@ class DecisionWorker:
                     PollForDecisionTaskRequest(
                         domain=self._client.domain,
                         task_list=TaskList(
-                            name=self._task_list, kind=TaskListKind.TASK_LIST_KIND_NORMAL
+                            name=self._task_list,
+                            kind=TaskListKind.TASK_LIST_KIND_NORMAL,
                         ),
                         identity=self._identity,
                     ),
@@ -86,30 +89,40 @@ class DecisionWorker:
             )
         except CadenceRpcError as e:
             elapsed = time.monotonic() - start
-            self._metrics_emitter.histogram(DECISION_POLL_LATENCY, elapsed, tags=self._tags)
+            self._metrics_emitter.histogram(
+                DECISION_POLL_LATENCY, elapsed, tags=self._tags
+            )
             if e.code in RETRYABLE_CODES:
                 self._metrics_emitter.counter(
                     DECISION_POLL_TRANSIENT_FAILED_COUNTER, tags=self._tags
                 )
             else:
-                self._metrics_emitter.counter(DECISION_POLL_FAILED_COUNTER, tags=self._tags)
+                self._metrics_emitter.counter(
+                    DECISION_POLL_FAILED_COUNTER, tags=self._tags
+                )
             raise
 
         elapsed = time.monotonic() - start
         self._metrics_emitter.histogram(DECISION_POLL_LATENCY, elapsed, tags=self._tags)
 
         if task and task.task_token:
-            self._metrics_emitter.counter(DECISION_POLL_SUCCEED_COUNTER, tags=self._tags)
+            self._metrics_emitter.counter(
+                DECISION_POLL_SUCCEED_COUNTER, tags=self._tags
+            )
             if task.scheduled_time.seconds and task.started_time.seconds:
                 scheduled_to_start = (
                     task.started_time.seconds + task.started_time.nanos / 1e9
                 ) - (task.scheduled_time.seconds + task.scheduled_time.nanos / 1e9)
                 self._metrics_emitter.histogram(
-                    DECISION_SCHEDULED_TO_START_LATENCY, scheduled_to_start, tags=self._tags
+                    DECISION_SCHEDULED_TO_START_LATENCY,
+                    scheduled_to_start,
+                    tags=self._tags,
                 )
             return task
         else:
-            self._metrics_emitter.counter(DECISION_POLL_NO_TASK_COUNTER, tags=self._tags)
+            self._metrics_emitter.counter(
+                DECISION_POLL_NO_TASK_COUNTER, tags=self._tags
+            )
             return None
 
     async def _execute(self, task: PollForDecisionTaskResponse) -> None:

--- a/cadence/worker/_decision.py
+++ b/cadence/worker/_decision.py
@@ -8,7 +8,6 @@ from cadence.api.v1.service_worker_pb2 import (
 )
 from cadence.api.v1.tasklist_pb2 import TaskList, TaskListKind
 from cadence.client import Client
-from cadence.error import CadenceRpcError
 from cadence.metrics import MetricsEmitter
 from cadence.metrics.constants import (
     DECISION_POLL_COUNTER,
@@ -73,8 +72,7 @@ class DecisionWorker:
         )
 
     async def _poll(self) -> Optional[PollForDecisionTaskResponse]:
-        start = self._poll_metrics.start_poll()
-        try:
+        async with self._poll_metrics.track() as start:
             task: PollForDecisionTaskResponse = (
                 await self._client.worker_stub.PollForDecisionTask(
                     PollForDecisionTaskRequest(
@@ -88,11 +86,8 @@ class DecisionWorker:
                     timeout=_LONG_POLL_TIMEOUT,
                 )
             )
-        except CadenceRpcError as e:
-            self._poll_metrics.record_failure(start, e)
-            raise
-        self._poll_metrics.record_result(start, task)
-        return task if (task and task.task_token) else None
+            self._poll_metrics.record_result(start, task)
+            return task if (task and task.task_token) else None
 
     async def _execute(self, task: PollForDecisionTaskResponse) -> None:
         await self._decision_handler.handle_task(task)

--- a/cadence/worker/_decision.py
+++ b/cadence/worker/_decision.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
@@ -8,6 +9,23 @@ from cadence.api.v1.service_worker_pb2 import (
 )
 from cadence.api.v1.tasklist_pb2 import TaskList, TaskListKind
 from cadence.client import Client
+from cadence.error import CadenceRpcError
+from cadence.metrics import MetricsEmitter, NoOpMetricsEmitter
+from cadence.metrics.constants import (
+    DECISION_POLL_COUNTER,
+    DECISION_POLL_FAILED_COUNTER,
+    DECISION_POLL_LATENCY,
+    DECISION_POLL_NO_TASK_COUNTER,
+    DECISION_POLL_SUCCEED_COUNTER,
+    DECISION_POLL_TRANSIENT_FAILED_COUNTER,
+    DECISION_SCHEDULED_TO_START_LATENCY,
+    POLLER_START_COUNTER,
+    TAG_DOMAIN,
+    TAG_TASK_LIST,
+    WORKER_PANIC_COUNTER,
+    WORKER_START_COUNTER,
+)
+from cadence._internal.rpc.retry import RETRYABLE_CODES
 from cadence.worker._decision_task_handler import DecisionTaskHandler
 from cadence.worker._poller import Poller
 from cadence.worker._registry import Registry
@@ -22,6 +40,11 @@ class DecisionWorker:
         self._task_list = task_list
         self._registry = registry
         self._identity = options["identity"]
+        self._metrics_emitter: MetricsEmitter = options.get(  # type: ignore[attr-defined]
+            "metrics_emitter", NoOpMetricsEmitter()
+        )
+        self._tags = {TAG_DOMAIN: client.domain, TAG_TASK_LIST: task_list}
+        self._num_pollers = options["decision_task_pollers"]
         permits = asyncio.Semaphore(
             options["max_concurrent_decision_task_execution_size"]
         )
@@ -32,30 +55,61 @@ class DecisionWorker:
             client, task_list, registry, executor=executor, **options
         )
         self._poller = Poller[PollForDecisionTaskResponse](
-            options["decision_task_pollers"], permits, self._poll, self._execute
+            self._num_pollers, permits, self._poll, self._execute
         )
         # TODO: Sticky poller, actually running workflows, etc.
 
     async def run(self) -> None:
-        await self._poller.run()
+        self._metrics_emitter.counter(WORKER_START_COUNTER, tags=self._tags)
+        self._metrics_emitter.counter(POLLER_START_COUNTER, self._num_pollers, tags=self._tags)
+        try:
+            await self._poller.run()
+        except Exception:
+            self._metrics_emitter.counter(WORKER_PANIC_COUNTER, tags=self._tags)
+            raise
 
     async def _poll(self) -> Optional[PollForDecisionTaskResponse]:
-        task: PollForDecisionTaskResponse = (
-            await self._client.worker_stub.PollForDecisionTask(
-                PollForDecisionTaskRequest(
-                    domain=self._client.domain,
-                    task_list=TaskList(
-                        name=self._task_list, kind=TaskListKind.TASK_LIST_KIND_NORMAL
+        self._metrics_emitter.counter(DECISION_POLL_COUNTER, tags=self._tags)
+        start = time.monotonic()
+        try:
+            task: PollForDecisionTaskResponse = (
+                await self._client.worker_stub.PollForDecisionTask(
+                    PollForDecisionTaskRequest(
+                        domain=self._client.domain,
+                        task_list=TaskList(
+                            name=self._task_list, kind=TaskListKind.TASK_LIST_KIND_NORMAL
+                        ),
+                        identity=self._identity,
                     ),
-                    identity=self._identity,
-                ),
-                timeout=_LONG_POLL_TIMEOUT,
+                    timeout=_LONG_POLL_TIMEOUT,
+                )
             )
-        )
+        except CadenceRpcError as e:
+            elapsed = time.monotonic() - start
+            self._metrics_emitter.histogram(DECISION_POLL_LATENCY, elapsed, tags=self._tags)
+            if e.code in RETRYABLE_CODES:
+                self._metrics_emitter.counter(
+                    DECISION_POLL_TRANSIENT_FAILED_COUNTER, tags=self._tags
+                )
+            else:
+                self._metrics_emitter.counter(DECISION_POLL_FAILED_COUNTER, tags=self._tags)
+            raise
+
+        elapsed = time.monotonic() - start
+        self._metrics_emitter.histogram(DECISION_POLL_LATENCY, elapsed, tags=self._tags)
 
         if task and task.task_token:
+            self._metrics_emitter.counter(DECISION_POLL_SUCCEED_COUNTER, tags=self._tags)
+            if task.scheduled_time.seconds and task.started_time.seconds:
+                scheduled_to_start = (
+                    task.started_time.seconds + task.started_time.nanos / 1e9
+                ) - (task.scheduled_time.seconds + task.scheduled_time.nanos / 1e9)
+                self._metrics_emitter.histogram(
+                    DECISION_SCHEDULED_TO_START_LATENCY, scheduled_to_start, tags=self._tags
+                )
             return task
         else:
+            self._metrics_emitter.counter(DECISION_POLL_NO_TASK_COUNTER, tags=self._tags)
             return None
 
     async def _execute(self, task: PollForDecisionTaskResponse) -> None:

--- a/cadence/worker/_decision.py
+++ b/cadence/worker/_decision.py
@@ -17,11 +17,13 @@ from cadence.metrics.constants import (
     DECISION_POLL_SUCCEED_COUNTER,
     DECISION_POLL_TRANSIENT_FAILED_COUNTER,
     DECISION_SCHEDULED_TO_START_LATENCY,
+    POLLER_START_COUNTER,
     TAG_DOMAIN,
     TAG_TASK_LIST,
+    WORKER_START_COUNTER,
 )
 from cadence.worker._decision_task_handler import DecisionTaskHandler
-from cadence.worker._poll_metrics import PollMetrics, run_with_lifecycle_metrics
+from cadence.worker._poll_metrics import PollMetrics
 from cadence.worker._poller import Poller
 from cadence.worker._registry import Registry
 from cadence.worker._types import _LONG_POLL_TIMEOUT, WorkerOptions
@@ -36,11 +38,12 @@ class DecisionWorker:
         self._registry = registry
         self._identity = options["identity"]
         self._metrics_emitter: MetricsEmitter = options["metrics_emitter"]
-        self._tags = {TAG_DOMAIN: client.domain, TAG_TASK_LIST: task_list}
+        self._tagged_emitter = self._metrics_emitter.with_tags(
+            {TAG_DOMAIN: client.domain, TAG_TASK_LIST: task_list}
+        )
         self._num_pollers = options["decision_task_pollers"]
         self._poll_metrics = PollMetrics(
-            emitter=self._metrics_emitter,
-            tags=self._tags,
+            emitter=self._tagged_emitter,
             poll=DECISION_POLL_COUNTER,
             latency=DECISION_POLL_LATENCY,
             succeed=DECISION_POLL_SUCCEED_COUNTER,
@@ -64,12 +67,9 @@ class DecisionWorker:
         # TODO: Sticky poller, actually running workflows, etc.
 
     async def run(self) -> None:
-        await run_with_lifecycle_metrics(
-            self._metrics_emitter,
-            self._poller,
-            num_pollers=self._num_pollers,
-            tags=self._tags,
-        )
+        self._tagged_emitter.counter(WORKER_START_COUNTER)
+        self._tagged_emitter.counter(POLLER_START_COUNTER, self._num_pollers)
+        await self._poller.run()
 
     async def _poll(self) -> Optional[PollForDecisionTaskResponse]:
         async with self._poll_metrics.track() as start:

--- a/cadence/worker/_decision.py
+++ b/cadence/worker/_decision.py
@@ -20,6 +20,7 @@ from cadence.metrics.constants import (
     POLLER_START_COUNTER,
     TAG_DOMAIN,
     TAG_TASK_LIST,
+    WORKER_PANIC_COUNTER,
     WORKER_START_COUNTER,
 )
 from cadence.worker._decision_task_handler import DecisionTaskHandler
@@ -69,7 +70,11 @@ class DecisionWorker:
     async def run(self) -> None:
         self._tagged_emitter.counter(WORKER_START_COUNTER)
         self._tagged_emitter.counter(POLLER_START_COUNTER, self._num_pollers)
-        await self._poller.run()
+        try:
+            await self._poller.run()
+        except Exception:
+            self._tagged_emitter.counter(WORKER_PANIC_COUNTER)
+            raise
 
     async def _poll(self) -> Optional[PollForDecisionTaskResponse]:
         async with self._poll_metrics.track() as start:

--- a/cadence/worker/_poll_metrics.py
+++ b/cadence/worker/_poll_metrics.py
@@ -4,25 +4,27 @@ import contextlib
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Protocol
 
 from cadence._internal.rpc.retry import RETRYABLE_CODES
 from cadence.error import CadenceRpcError
 from cadence.metrics import MetricsEmitter
-from cadence.metrics.constants import (
-    POLLER_START_COUNTER,
-    WORKER_PANIC_COUNTER,
-    WORKER_START_COUNTER,
-)
-from cadence.worker._poller import Poller
 
-T = TypeVar("T")
+
+class _Timestamp(Protocol):
+    seconds: int
+    nanos: int
+
+
+class PollTask(Protocol):
+    task_token: bytes
+    scheduled_time: _Timestamp
+    started_time: _Timestamp
 
 
 @dataclass
 class PollMetrics:
-    emitter: MetricsEmitter
-    tags: dict[str, str]
+    emitter: MetricsEmitter  # should be pre-tagged via emitter.with_tags(...)
     poll: str
     latency: str
     succeed: str
@@ -34,45 +36,27 @@ class PollMetrics:
     @contextlib.asynccontextmanager
     async def track(self) -> AsyncIterator[float]:
         """Emit poll counter; guarantee exactly one outcome counter on error."""
-        self.emitter.counter(self.poll, tags=self.tags)
+        self.emitter.counter(self.poll)
         start = time.monotonic()
         try:
             yield start
         except CadenceRpcError as e:
-            self.emitter.histogram(
-                self.latency, time.monotonic() - start, tags=self.tags
-            )
+            self.emitter.histogram(self.latency, time.monotonic() - start)
             metric = self.transient_failed if e.code in RETRYABLE_CODES else self.failed
-            self.emitter.counter(metric, tags=self.tags)
+            self.emitter.counter(metric)
             raise
         except Exception:
-            self.emitter.counter(self.failed, tags=self.tags)
+            self.emitter.counter(self.failed)
             raise
 
-    def record_result(self, start: float, task: Any) -> None:
+    def record_result(self, start: float, task: PollTask) -> None:
         """Record latency, then succeed vs idle, and optional schedule-to-start lag."""
-        self.emitter.histogram(self.latency, time.monotonic() - start, tags=self.tags)
+        self.emitter.histogram(self.latency, time.monotonic() - start)
         if not (task and task.task_token):
-            self.emitter.counter(self.no_task, tags=self.tags)
+            self.emitter.counter(self.no_task)
             return
-        self.emitter.counter(self.succeed, tags=self.tags)
+        self.emitter.counter(self.succeed)
         s, e = task.scheduled_time, task.started_time
         if s.seconds and e.seconds:
             lag = (e.seconds + e.nanos / 1e9) - (s.seconds + s.nanos / 1e9)
-            self.emitter.histogram(self.scheduled_to_start, lag, tags=self.tags)
-
-
-async def run_with_lifecycle_metrics(
-    emitter: MetricsEmitter,
-    poller: Poller[T],
-    *,
-    num_pollers: int,
-    tags: dict[str, str],
-) -> None:
-    emitter.counter(WORKER_START_COUNTER, tags=tags)
-    emitter.counter(POLLER_START_COUNTER, num_pollers, tags=tags)
-    try:
-        await poller.run()
-    except Exception:
-        emitter.counter(WORKER_PANIC_COUNTER, tags=tags)
-        raise
+            self.emitter.histogram(self.scheduled_to_start, lag)

--- a/cadence/worker/_poll_metrics.py
+++ b/cadence/worker/_poll_metrics.py
@@ -6,20 +6,17 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Protocol
 
+from google.protobuf import timestamp_pb2
+
 from cadence._internal.rpc.retry import RETRYABLE_CODES
 from cadence.error import CadenceRpcError
 from cadence.metrics import MetricsEmitter
 
 
-class _Timestamp(Protocol):
-    seconds: int
-    nanos: int
-
-
 class PollTask(Protocol):
     task_token: bytes
-    scheduled_time: _Timestamp
-    started_time: _Timestamp
+    scheduled_time: timestamp_pb2.Timestamp
+    started_time: timestamp_pb2.Timestamp
 
 
 @dataclass
@@ -58,5 +55,5 @@ class PollMetrics:
         self.emitter.counter(self.succeed)
         s, e = task.scheduled_time, task.started_time
         if (s.seconds or s.nanos) and (e.seconds or e.nanos):
-            lag = (e.seconds + e.nanos / 1e9) - (s.seconds + s.nanos / 1e9)
+            lag = (e.ToDatetime() - s.ToDatetime()).total_seconds()
             self.emitter.histogram(self.scheduled_to_start, max(0.0, lag))

--- a/cadence/worker/_poll_metrics.py
+++ b/cadence/worker/_poll_metrics.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 import time
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
@@ -29,14 +31,23 @@ class PollMetrics:
     transient_failed: str
     scheduled_to_start: str
 
-    def start_poll(self) -> float:
+    @contextlib.asynccontextmanager
+    async def track(self) -> AsyncIterator[float]:
+        """Emit poll counter; guarantee exactly one outcome counter on error."""
         self.emitter.counter(self.poll, tags=self.tags)
-        return time.monotonic()
-
-    def record_failure(self, start: float, error: CadenceRpcError) -> None:
-        self.emitter.histogram(self.latency, time.monotonic() - start, tags=self.tags)
-        metric = self.transient_failed if error.code in RETRYABLE_CODES else self.failed
-        self.emitter.counter(metric, tags=self.tags)
+        start = time.monotonic()
+        try:
+            yield start
+        except CadenceRpcError as e:
+            self.emitter.histogram(
+                self.latency, time.monotonic() - start, tags=self.tags
+            )
+            metric = self.transient_failed if e.code in RETRYABLE_CODES else self.failed
+            self.emitter.counter(metric, tags=self.tags)
+            raise
+        except Exception:
+            self.emitter.counter(self.failed, tags=self.tags)
+            raise
 
     def record_result(self, start: float, task: Any) -> None:
         """Record latency, then succeed vs idle, and optional schedule-to-start lag."""

--- a/cadence/worker/_poll_metrics.py
+++ b/cadence/worker/_poll_metrics.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+from cadence._internal.rpc.retry import RETRYABLE_CODES
+from cadence.error import CadenceRpcError
+from cadence.metrics import MetricsEmitter
+from cadence.metrics.constants import (
+    POLLER_START_COUNTER,
+    WORKER_PANIC_COUNTER,
+    WORKER_START_COUNTER,
+)
+from cadence.worker._poller import Poller
+
+T = TypeVar("T")
+
+
+@dataclass
+class PollMetrics:
+    emitter: MetricsEmitter
+    tags: dict[str, str]
+    poll: str
+    latency: str
+    succeed: str
+    no_task: str
+    failed: str
+    transient_failed: str
+    scheduled_to_start: str
+
+    def start_poll(self) -> float:
+        self.emitter.counter(self.poll, tags=self.tags)
+        return time.monotonic()
+
+    def record_failure(self, start: float, error: CadenceRpcError) -> None:
+        self.emitter.histogram(self.latency, time.monotonic() - start, tags=self.tags)
+        metric = self.transient_failed if error.code in RETRYABLE_CODES else self.failed
+        self.emitter.counter(metric, tags=self.tags)
+
+    def record_result(self, start: float, task: Any) -> None:
+        """Record latency, then succeed vs idle, and optional schedule-to-start lag."""
+        self.emitter.histogram(self.latency, time.monotonic() - start, tags=self.tags)
+        if not (task and task.task_token):
+            self.emitter.counter(self.no_task, tags=self.tags)
+            return
+        self.emitter.counter(self.succeed, tags=self.tags)
+        s, e = task.scheduled_time, task.started_time
+        if s.seconds and e.seconds:
+            lag = (e.seconds + e.nanos / 1e9) - (s.seconds + s.nanos / 1e9)
+            self.emitter.histogram(self.scheduled_to_start, lag, tags=self.tags)
+
+
+async def run_with_lifecycle_metrics(
+    emitter: MetricsEmitter,
+    poller: Poller[T],
+    *,
+    num_pollers: int,
+    tags: dict[str, str],
+) -> None:
+    emitter.counter(WORKER_START_COUNTER, tags=tags)
+    emitter.counter(POLLER_START_COUNTER, num_pollers, tags=tags)
+    try:
+        await poller.run()
+    except Exception:
+        emitter.counter(WORKER_PANIC_COUNTER, tags=tags)
+        raise

--- a/cadence/worker/_poll_metrics.py
+++ b/cadence/worker/_poll_metrics.py
@@ -57,6 +57,6 @@ class PollMetrics:
             return
         self.emitter.counter(self.succeed)
         s, e = task.scheduled_time, task.started_time
-        if s.seconds and e.seconds:
+        if (s.seconds or s.nanos) and (e.seconds or e.nanos):
             lag = (e.seconds + e.nanos / 1e9) - (s.seconds + s.nanos / 1e9)
-            self.emitter.histogram(self.scheduled_to_start, lag)
+            self.emitter.histogram(self.scheduled_to_start, max(0.0, lag))

--- a/cadence/worker/_poller.py
+++ b/cadence/worker/_poller.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
-from typing import Callable, TypeVar, Generic, Awaitable, Optional
+from collections.abc import Awaitable, Callable
+from typing import Generic, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -12,20 +13,24 @@ class Poller(Generic[T]):
         self,
         num_tasks: int,
         permits: asyncio.Semaphore,
-        poll: Callable[[], Awaitable[Optional[T]]],
+        poll: Callable[[], Awaitable[T | None]],
         callback: Callable[[T], Awaitable[None]],
+        on_start: Callable[[int], None] | None = None,
     ) -> None:
         self._num_tasks = num_tasks
         self._permits = permits
         self._poll = poll
         self._callback = callback
+        self._on_start = on_start
         self._background_tasks: set[asyncio.Task[None]] = set()
 
     async def run(self) -> None:
         try:
             async with asyncio.TaskGroup() as tg:
-                for i in range(self._num_tasks):
+                for _ in range(self._num_tasks):
                     tg.create_task(self._poll_loop())
+                if self._on_start is not None:
+                    self._on_start(self._num_tasks)
         except asyncio.CancelledError:
             pass
 

--- a/tests/cadence/worker/test_decision_worker_integration.py
+++ b/tests/cadence/worker/test_decision_worker_integration.py
@@ -8,6 +8,7 @@ from cadence.api.v1.history_pb2 import (
     HistoryEvent,
     WorkflowExecutionStartedEventAttributes,
 )
+from cadence.metrics import NoOpMetricsEmitter
 from cadence.worker import WorkerOptions
 from cadence.worker._decision import DecisionWorker
 from cadence.worker._registry import Registry
@@ -52,6 +53,7 @@ class TestDecisionWorkerIntegration:
             identity="test-worker",
             max_concurrent_decision_task_execution_size=1,
             decision_task_pollers=1,
+            metrics_emitter=NoOpMetricsEmitter(),
         )
         return DecisionWorker(
             client=mock_client,
@@ -297,6 +299,7 @@ class TestDecisionWorkerIntegration:
             identity="custom-worker",
             max_concurrent_decision_task_execution_size=5,
             decision_task_pollers=3,
+            metrics_emitter=NoOpMetricsEmitter(),
         )
 
         worker = DecisionWorker(

--- a/tests/cadence/worker/test_poll_metrics.py
+++ b/tests/cadence/worker/test_poll_metrics.py
@@ -94,6 +94,10 @@ class TestDecisionWorkerRunMetrics:
             await worker.run()
 
         emitter.counter.assert_any_call(WORKER_START_COUNTER, 1, tags=EXPECTED_TAGS)
+        assert not any(
+            call.args[0] == POLLER_START_COUNTER
+            for call in emitter.counter.call_args_list
+        )
 
     @pytest.mark.asyncio
     async def test_emits_poller_start_counter_with_configured_count(self):
@@ -101,7 +105,7 @@ class TestDecisionWorkerRunMetrics:
         options = _worker_options(emitter)
         options["decision_task_pollers"] = 3
         worker = DecisionWorker(_mock_client(), TASK_LIST, Registry(), options)
-        with patch.object(worker._poller, "run", new=AsyncMock()):
+        with patch.object(worker._poller, "_poll_loop", new_callable=AsyncMock):
             await worker.run()
 
         emitter.counter.assert_any_call(POLLER_START_COUNTER, 3, tags=EXPECTED_TAGS)
@@ -283,6 +287,10 @@ class TestActivityWorkerRunMetrics:
             await worker.run()
 
         emitter.counter.assert_any_call(WORKER_START_COUNTER, 1, tags=EXPECTED_TAGS)
+        assert not any(
+            call.args[0] == POLLER_START_COUNTER
+            for call in emitter.counter.call_args_list
+        )
 
     @pytest.mark.asyncio
     async def test_emits_poller_start_counter_with_configured_count(self):
@@ -290,7 +298,7 @@ class TestActivityWorkerRunMetrics:
         options = _worker_options(emitter)
         options["activity_task_pollers"] = 5
         worker = ActivityWorker(_mock_client(), TASK_LIST, Registry(), options)
-        with patch.object(worker._poller, "run", new=AsyncMock()):
+        with patch.object(worker._poller, "_poll_loop", new_callable=AsyncMock):
             await worker.run()
 
         emitter.counter.assert_any_call(POLLER_START_COUNTER, 5, tags=EXPECTED_TAGS)

--- a/tests/cadence/worker/test_poll_metrics.py
+++ b/tests/cadence/worker/test_poll_metrics.py
@@ -26,6 +26,7 @@ from cadence.metrics.constants import (
     POLLER_START_COUNTER,
     TAG_DOMAIN,
     TAG_TASK_LIST,
+    WORKER_PANIC_COUNTER,
     WORKER_START_COUNTER,
 )
 from cadence.worker._activity import ActivityWorker
@@ -103,6 +104,34 @@ class TestDecisionWorkerRunMetrics:
             await worker.run()
 
         emitter.counter.assert_any_call(POLLER_START_COUNTER, 3, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_emits_worker_panic_counter_on_exception(self):
+        emitter = _mock_emitter()
+        worker = DecisionWorker(
+            _mock_client(), TASK_LIST, Registry(), _worker_options(emitter)
+        )
+        with patch.object(
+            worker._poller,
+            "run",
+            new=AsyncMock(side_effect=RuntimeError("unexpected")),
+        ):
+            with pytest.raises(RuntimeError):
+                await worker.run()
+
+        emitter.counter.assert_any_call(WORKER_PANIC_COUNTER, 1, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_no_panic_counter_on_normal_exit(self):
+        emitter = _mock_emitter()
+        worker = DecisionWorker(
+            _mock_client(), TASK_LIST, Registry(), _worker_options(emitter)
+        )
+        with patch.object(worker._poller, "run", new=AsyncMock()):
+            await worker.run()
+
+        calls = [str(c) for c in emitter.counter.call_args_list]
+        assert not any(WORKER_PANIC_COUNTER in c for c in calls)
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +277,34 @@ class TestActivityWorkerRunMetrics:
             await worker.run()
 
         emitter.counter.assert_any_call(POLLER_START_COUNTER, 5, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_emits_worker_panic_counter_on_exception(self):
+        emitter = _mock_emitter()
+        worker = ActivityWorker(
+            _mock_client(), TASK_LIST, Registry(), _worker_options(emitter)
+        )
+        with patch.object(
+            worker._poller,
+            "run",
+            new=AsyncMock(side_effect=RuntimeError("unexpected")),
+        ):
+            with pytest.raises(RuntimeError):
+                await worker.run()
+
+        emitter.counter.assert_any_call(WORKER_PANIC_COUNTER, 1, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_no_panic_counter_on_normal_exit(self):
+        emitter = _mock_emitter()
+        worker = ActivityWorker(
+            _mock_client(), TASK_LIST, Registry(), _worker_options(emitter)
+        )
+        with patch.object(worker._poller, "run", new=AsyncMock()):
+            await worker.run()
+
+        calls = [str(c) for c in emitter.counter.call_args_list]
+        assert not any(WORKER_PANIC_COUNTER in c for c in calls)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cadence/worker/test_poll_metrics.py
+++ b/tests/cadence/worker/test_poll_metrics.py
@@ -1,7 +1,7 @@
 """Tests for poll and worker-start metrics in DecisionWorker and ActivityWorker."""
 
 import pytest
-from unittest.mock import AsyncMock, Mock, PropertyMock
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from cadence.client import Client
@@ -84,10 +84,11 @@ class TestDecisionWorkerRunMetrics:
     @pytest.mark.asyncio
     async def test_emits_worker_start_counter(self):
         emitter = _mock_emitter()
-        worker = DecisionWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
-        worker._poller.run = AsyncMock()
-
-        await worker.run()
+        worker = DecisionWorker(
+            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
+        )
+        with patch.object(worker._poller, "run", new=AsyncMock()):
+            await worker.run()
 
         emitter.counter.assert_any_call(WORKER_START_COUNTER, tags=EXPECTED_TAGS)
 
@@ -97,30 +98,35 @@ class TestDecisionWorkerRunMetrics:
         options = _decision_options(emitter)
         options["decision_task_pollers"] = 3
         worker = DecisionWorker(_mock_client(), TASK_LIST, Registry(), options)
-        worker._poller.run = AsyncMock()
-
-        await worker.run()
+        with patch.object(worker._poller, "run", new=AsyncMock()):
+            await worker.run()
 
         emitter.counter.assert_any_call(POLLER_START_COUNTER, 3, tags=EXPECTED_TAGS)
 
     @pytest.mark.asyncio
     async def test_emits_worker_panic_counter_on_exception(self):
         emitter = _mock_emitter()
-        worker = DecisionWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
-        worker._poller.run = AsyncMock(side_effect=RuntimeError("unexpected"))
-
-        with pytest.raises(RuntimeError):
-            await worker.run()
+        worker = DecisionWorker(
+            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
+        )
+        with patch.object(
+            worker._poller,
+            "run",
+            new=AsyncMock(side_effect=RuntimeError("unexpected")),
+        ):
+            with pytest.raises(RuntimeError):
+                await worker.run()
 
         emitter.counter.assert_any_call(WORKER_PANIC_COUNTER, tags=EXPECTED_TAGS)
 
     @pytest.mark.asyncio
     async def test_no_panic_counter_on_normal_exit(self):
         emitter = _mock_emitter()
-        worker = DecisionWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
-        worker._poller.run = AsyncMock()
-
-        await worker.run()
+        worker = DecisionWorker(
+            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
+        )
+        with patch.object(worker._poller, "run", new=AsyncMock()):
+            await worker.run()
 
         calls = [str(c) for c in emitter.counter.call_args_list]
         assert not any(WORKER_PANIC_COUNTER in c for c in calls)
@@ -139,13 +145,17 @@ class TestDecisionWorkerPollMetrics:
         client.worker_stub.PollForDecisionTask = AsyncMock(
             return_value=Mock(task_token=b"")
         )
-        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+        worker = DecisionWorker(
+            client, TASK_LIST, Registry(), _decision_options(emitter)
+        )
 
         result = await worker._poll()
 
         assert result is None
         emitter.counter.assert_any_call(DECISION_POLL_COUNTER, tags=EXPECTED_TAGS)
-        emitter.counter.assert_any_call(DECISION_POLL_NO_TASK_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(
+            DECISION_POLL_NO_TASK_COUNTER, tags=EXPECTED_TAGS
+        )
         assert any(
             c.args[0] == DECISION_POLL_LATENCY for c in emitter.histogram.call_args_list
         )
@@ -159,13 +169,17 @@ class TestDecisionWorkerPollMetrics:
         mock_task.scheduled_time = _make_ts(0)
         mock_task.started_time = _make_ts(0)
         client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
-        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+        worker = DecisionWorker(
+            client, TASK_LIST, Registry(), _decision_options(emitter)
+        )
 
         result = await worker._poll()
 
         assert result is mock_task
         emitter.counter.assert_any_call(DECISION_POLL_COUNTER, tags=EXPECTED_TAGS)
-        emitter.counter.assert_any_call(DECISION_POLL_SUCCEED_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(
+            DECISION_POLL_SUCCEED_COUNTER, tags=EXPECTED_TAGS
+        )
 
     @pytest.mark.asyncio
     async def test_emits_scheduled_to_start_latency_when_timestamps_set(self):
@@ -176,7 +190,9 @@ class TestDecisionWorkerPollMetrics:
         mock_task.scheduled_time = _make_ts(1000)
         mock_task.started_time = _make_ts(1002)
         client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
-        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+        worker = DecisionWorker(
+            client, TASK_LIST, Registry(), _decision_options(emitter)
+        )
 
         await worker._poll()
 
@@ -194,7 +210,9 @@ class TestDecisionWorkerPollMetrics:
         mock_task.scheduled_time = _make_ts(0)
         mock_task.started_time = _make_ts(0)
         client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
-        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+        worker = DecisionWorker(
+            client, TASK_LIST, Registry(), _decision_options(emitter)
+        )
 
         await worker._poll()
 
@@ -208,7 +226,9 @@ class TestDecisionWorkerPollMetrics:
         client.worker_stub.PollForDecisionTask = AsyncMock(
             side_effect=CadenceRpcError("unavailable", StatusCode.UNAVAILABLE)
         )
-        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+        worker = DecisionWorker(
+            client, TASK_LIST, Registry(), _decision_options(emitter)
+        )
 
         with pytest.raises(CadenceRpcError):
             await worker._poll()
@@ -228,12 +248,16 @@ class TestDecisionWorkerPollMetrics:
         client.worker_stub.PollForDecisionTask = AsyncMock(
             side_effect=CadenceRpcError("not found", StatusCode.NOT_FOUND)
         )
-        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+        worker = DecisionWorker(
+            client, TASK_LIST, Registry(), _decision_options(emitter)
+        )
 
         with pytest.raises(CadenceRpcError):
             await worker._poll()
 
-        emitter.counter.assert_any_call(DECISION_POLL_FAILED_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(
+            DECISION_POLL_FAILED_COUNTER, tags=EXPECTED_TAGS
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -245,10 +269,11 @@ class TestActivityWorkerRunMetrics:
     @pytest.mark.asyncio
     async def test_emits_worker_start_counter(self):
         emitter = _mock_emitter()
-        worker = ActivityWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
-        worker._poller.run = AsyncMock()
-
-        await worker.run()
+        worker = ActivityWorker(
+            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
+        )
+        with patch.object(worker._poller, "run", new=AsyncMock()):
+            await worker.run()
 
         emitter.counter.assert_any_call(WORKER_START_COUNTER, tags=EXPECTED_TAGS)
 
@@ -258,30 +283,35 @@ class TestActivityWorkerRunMetrics:
         options = _decision_options(emitter)
         options["activity_task_pollers"] = 5
         worker = ActivityWorker(_mock_client(), TASK_LIST, Registry(), options)
-        worker._poller.run = AsyncMock()
-
-        await worker.run()
+        with patch.object(worker._poller, "run", new=AsyncMock()):
+            await worker.run()
 
         emitter.counter.assert_any_call(POLLER_START_COUNTER, 5, tags=EXPECTED_TAGS)
 
     @pytest.mark.asyncio
     async def test_emits_worker_panic_counter_on_exception(self):
         emitter = _mock_emitter()
-        worker = ActivityWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
-        worker._poller.run = AsyncMock(side_effect=RuntimeError("unexpected"))
-
-        with pytest.raises(RuntimeError):
-            await worker.run()
+        worker = ActivityWorker(
+            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
+        )
+        with patch.object(
+            worker._poller,
+            "run",
+            new=AsyncMock(side_effect=RuntimeError("unexpected")),
+        ):
+            with pytest.raises(RuntimeError):
+                await worker.run()
 
         emitter.counter.assert_any_call(WORKER_PANIC_COUNTER, tags=EXPECTED_TAGS)
 
     @pytest.mark.asyncio
     async def test_no_panic_counter_on_normal_exit(self):
         emitter = _mock_emitter()
-        worker = ActivityWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
-        worker._poller.run = AsyncMock()
-
-        await worker.run()
+        worker = ActivityWorker(
+            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
+        )
+        with patch.object(worker._poller, "run", new=AsyncMock()):
+            await worker.run()
 
         calls = [str(c) for c in emitter.counter.call_args_list]
         assert not any(WORKER_PANIC_COUNTER in c for c in calls)
@@ -300,13 +330,17 @@ class TestActivityWorkerPollMetrics:
         client.worker_stub.PollForActivityTask = AsyncMock(
             return_value=Mock(task_token=b"")
         )
-        worker = ActivityWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+        worker = ActivityWorker(
+            client, TASK_LIST, Registry(), _decision_options(emitter)
+        )
 
         result = await worker._poll()
 
         assert result is None
         emitter.counter.assert_any_call(ACTIVITY_POLL_COUNTER, tags=EXPECTED_TAGS)
-        emitter.counter.assert_any_call(ACTIVITY_POLL_NO_TASK_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(
+            ACTIVITY_POLL_NO_TASK_COUNTER, tags=EXPECTED_TAGS
+        )
         assert any(
             c.args[0] == ACTIVITY_POLL_LATENCY for c in emitter.histogram.call_args_list
         )
@@ -320,13 +354,17 @@ class TestActivityWorkerPollMetrics:
         mock_task.scheduled_time = _make_ts(0)
         mock_task.started_time = _make_ts(0)
         client.worker_stub.PollForActivityTask = AsyncMock(return_value=mock_task)
-        worker = ActivityWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+        worker = ActivityWorker(
+            client, TASK_LIST, Registry(), _decision_options(emitter)
+        )
 
         result = await worker._poll()
 
         assert result is mock_task
         emitter.counter.assert_any_call(ACTIVITY_POLL_COUNTER, tags=EXPECTED_TAGS)
-        emitter.counter.assert_any_call(ACTIVITY_POLL_SUCCEED_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(
+            ACTIVITY_POLL_SUCCEED_COUNTER, tags=EXPECTED_TAGS
+        )
 
     @pytest.mark.asyncio
     async def test_emits_scheduled_to_start_latency_when_timestamps_set(self):
@@ -337,22 +375,31 @@ class TestActivityWorkerPollMetrics:
         mock_task.scheduled_time = _make_ts(500)
         mock_task.started_time = _make_ts(503)
         client.worker_stub.PollForActivityTask = AsyncMock(return_value=mock_task)
-        worker = ActivityWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+        worker = ActivityWorker(
+            client, TASK_LIST, Registry(), _decision_options(emitter)
+        )
 
         await worker._poll()
 
         histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
         assert ACTIVITY_SCHEDULED_TO_START_LATENCY in histogram_calls
-        assert abs(histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] - 3.0) < 0.01
+        assert (
+            abs(histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] - 3.0)
+            < 0.01
+        )
 
     @pytest.mark.asyncio
     async def test_emits_transient_failed_counter_on_retryable_error(self):
         emitter = _mock_emitter()
         client = _mock_client()
         client.worker_stub.PollForActivityTask = AsyncMock(
-            side_effect=CadenceRpcError("resource exhausted", StatusCode.RESOURCE_EXHAUSTED)
+            side_effect=CadenceRpcError(
+                "resource exhausted", StatusCode.RESOURCE_EXHAUSTED
+            )
         )
-        worker = ActivityWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+        worker = ActivityWorker(
+            client, TASK_LIST, Registry(), _decision_options(emitter)
+        )
 
         with pytest.raises(CadenceRpcError):
             await worker._poll()
@@ -367,11 +414,17 @@ class TestActivityWorkerPollMetrics:
         emitter = _mock_emitter()
         client = _mock_client()
         client.worker_stub.PollForActivityTask = AsyncMock(
-            side_effect=CadenceRpcError("permission denied", StatusCode.PERMISSION_DENIED)
+            side_effect=CadenceRpcError(
+                "permission denied", StatusCode.PERMISSION_DENIED
+            )
         )
-        worker = ActivityWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+        worker = ActivityWorker(
+            client, TASK_LIST, Registry(), _decision_options(emitter)
+        )
 
         with pytest.raises(CadenceRpcError):
             await worker._poll()
 
-        emitter.counter.assert_any_call(ACTIVITY_POLL_FAILED_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(
+            ACTIVITY_POLL_FAILED_COUNTER, tags=EXPECTED_TAGS
+        )

--- a/tests/cadence/worker/test_poll_metrics.py
+++ b/tests/cadence/worker/test_poll_metrics.py
@@ -71,9 +71,10 @@ def _worker_options(emitter) -> WorkerOptions:
     }
 
 
-def _make_ts(seconds: int) -> Timestamp:
+def _make_ts(seconds: int, nanos: int = 0) -> Timestamp:
     ts = Timestamp()
     ts.seconds = seconds
+    ts.nanos = nanos
     return ts
 
 
@@ -212,6 +213,22 @@ class TestDecisionWorkerPollMetrics:
 
         histogram_names = [c.args[0] for c in emitter.histogram.call_args_list]
         assert DECISION_SCHEDULED_TO_START_LATENCY not in histogram_names
+
+    @pytest.mark.asyncio
+    async def test_clamps_negative_scheduled_to_start_latency(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        mock_task = Mock()
+        mock_task.task_token = b"token"
+        mock_task.scheduled_time = _make_ts(1002)
+        mock_task.started_time = _make_ts(1000)
+        client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
+
+        await worker._poll()
+
+        histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
+        assert histogram_calls[DECISION_SCHEDULED_TO_START_LATENCY].args[1] == 0.0
 
     @pytest.mark.asyncio
     async def test_emits_transient_failed_counter_on_retryable_error(self):
@@ -369,6 +386,25 @@ class TestActivityWorkerPollMetrics:
         assert ACTIVITY_SCHEDULED_TO_START_LATENCY in histogram_calls
         assert (
             abs(histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] - 3.0)
+            < 0.01
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_scheduled_to_start_latency_when_only_nanos_set(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        mock_task = Mock()
+        mock_task.task_token = b"token"
+        mock_task.scheduled_time = _make_ts(0, 100_000_000)
+        mock_task.started_time = _make_ts(0, 300_000_000)
+        client.worker_stub.PollForActivityTask = AsyncMock(return_value=mock_task)
+        worker = ActivityWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
+
+        await worker._poll()
+
+        histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
+        assert (
+            abs(histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] - 0.2)
             < 0.01
         )
 

--- a/tests/cadence/worker/test_poll_metrics.py
+++ b/tests/cadence/worker/test_poll_metrics.py
@@ -7,6 +7,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from cadence.client import Client
 from cadence.error import CadenceRpcError
 from cadence.metrics import MetricsEmitter, NoOpMetricsEmitter
+from cadence.metrics.metrics import _TaggedEmitter
 from cadence.metrics.constants import (
     ACTIVITY_POLL_COUNTER,
     ACTIVITY_POLL_FAILED_COUNTER,
@@ -25,7 +26,6 @@ from cadence.metrics.constants import (
     POLLER_START_COUNTER,
     TAG_DOMAIN,
     TAG_TASK_LIST,
-    WORKER_PANIC_COUNTER,
     WORKER_START_COUNTER,
 )
 from cadence.worker._activity import ActivityWorker
@@ -41,6 +41,7 @@ EXPECTED_TAGS = {TAG_DOMAIN: DOMAIN, TAG_TASK_LIST: TASK_LIST}
 
 def _mock_emitter() -> Mock:
     emitter = Mock(spec=MetricsEmitter)
+    emitter.with_tags.side_effect = lambda tags: _TaggedEmitter(emitter, tags)
     return emitter
 
 
@@ -56,7 +57,7 @@ def _mock_client() -> Mock:
     return client
 
 
-def _decision_options(emitter) -> WorkerOptions:
+def _worker_options(emitter) -> WorkerOptions:
     return {
         "identity": "test-id",
         "metrics_emitter": emitter,
@@ -85,51 +86,23 @@ class TestDecisionWorkerRunMetrics:
     async def test_emits_worker_start_counter(self):
         emitter = _mock_emitter()
         worker = DecisionWorker(
-            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
+            _mock_client(), TASK_LIST, Registry(), _worker_options(emitter)
         )
         with patch.object(worker._poller, "run", new=AsyncMock()):
             await worker.run()
 
-        emitter.counter.assert_any_call(WORKER_START_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(WORKER_START_COUNTER, 1, tags=EXPECTED_TAGS)
 
     @pytest.mark.asyncio
     async def test_emits_poller_start_counter_with_configured_count(self):
         emitter = _mock_emitter()
-        options = _decision_options(emitter)
+        options = _worker_options(emitter)
         options["decision_task_pollers"] = 3
         worker = DecisionWorker(_mock_client(), TASK_LIST, Registry(), options)
         with patch.object(worker._poller, "run", new=AsyncMock()):
             await worker.run()
 
         emitter.counter.assert_any_call(POLLER_START_COUNTER, 3, tags=EXPECTED_TAGS)
-
-    @pytest.mark.asyncio
-    async def test_emits_worker_panic_counter_on_exception(self):
-        emitter = _mock_emitter()
-        worker = DecisionWorker(
-            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
-        )
-        with patch.object(
-            worker._poller,
-            "run",
-            new=AsyncMock(side_effect=RuntimeError("unexpected")),
-        ):
-            with pytest.raises(RuntimeError):
-                await worker.run()
-
-        emitter.counter.assert_any_call(WORKER_PANIC_COUNTER, tags=EXPECTED_TAGS)
-
-    @pytest.mark.asyncio
-    async def test_no_panic_counter_on_normal_exit(self):
-        emitter = _mock_emitter()
-        worker = DecisionWorker(
-            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
-        )
-        with patch.object(worker._poller, "run", new=AsyncMock()):
-            await worker.run()
-
-        calls = [str(c) for c in emitter.counter.call_args_list]
-        assert not any(WORKER_PANIC_COUNTER in c for c in calls)
 
 
 # ---------------------------------------------------------------------------
@@ -145,16 +118,14 @@ class TestDecisionWorkerPollMetrics:
         client.worker_stub.PollForDecisionTask = AsyncMock(
             return_value=Mock(task_token=b"")
         )
-        worker = DecisionWorker(
-            client, TASK_LIST, Registry(), _decision_options(emitter)
-        )
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
         result = await worker._poll()
 
         assert result is None
-        emitter.counter.assert_any_call(DECISION_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(DECISION_POLL_COUNTER, 1, tags=EXPECTED_TAGS)
         emitter.counter.assert_any_call(
-            DECISION_POLL_NO_TASK_COUNTER, tags=EXPECTED_TAGS
+            DECISION_POLL_NO_TASK_COUNTER, 1, tags=EXPECTED_TAGS
         )
         assert any(
             c.args[0] == DECISION_POLL_LATENCY for c in emitter.histogram.call_args_list
@@ -169,16 +140,14 @@ class TestDecisionWorkerPollMetrics:
         mock_task.scheduled_time = _make_ts(0)
         mock_task.started_time = _make_ts(0)
         client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
-        worker = DecisionWorker(
-            client, TASK_LIST, Registry(), _decision_options(emitter)
-        )
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
         result = await worker._poll()
 
         assert result is mock_task
-        emitter.counter.assert_any_call(DECISION_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(DECISION_POLL_COUNTER, 1, tags=EXPECTED_TAGS)
         emitter.counter.assert_any_call(
-            DECISION_POLL_SUCCEED_COUNTER, tags=EXPECTED_TAGS
+            DECISION_POLL_SUCCEED_COUNTER, 1, tags=EXPECTED_TAGS
         )
 
     @pytest.mark.asyncio
@@ -190,9 +159,7 @@ class TestDecisionWorkerPollMetrics:
         mock_task.scheduled_time = _make_ts(1000)
         mock_task.started_time = _make_ts(1002)
         client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
-        worker = DecisionWorker(
-            client, TASK_LIST, Registry(), _decision_options(emitter)
-        )
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
         await worker._poll()
 
@@ -210,9 +177,7 @@ class TestDecisionWorkerPollMetrics:
         mock_task.scheduled_time = _make_ts(0)
         mock_task.started_time = _make_ts(0)
         client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
-        worker = DecisionWorker(
-            client, TASK_LIST, Registry(), _decision_options(emitter)
-        )
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
         await worker._poll()
 
@@ -226,16 +191,14 @@ class TestDecisionWorkerPollMetrics:
         client.worker_stub.PollForDecisionTask = AsyncMock(
             side_effect=CadenceRpcError("unavailable", StatusCode.UNAVAILABLE)
         )
-        worker = DecisionWorker(
-            client, TASK_LIST, Registry(), _decision_options(emitter)
-        )
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
         with pytest.raises(CadenceRpcError):
             await worker._poll()
 
-        emitter.counter.assert_any_call(DECISION_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(DECISION_POLL_COUNTER, 1, tags=EXPECTED_TAGS)
         emitter.counter.assert_any_call(
-            DECISION_POLL_TRANSIENT_FAILED_COUNTER, tags=EXPECTED_TAGS
+            DECISION_POLL_TRANSIENT_FAILED_COUNTER, 1, tags=EXPECTED_TAGS
         )
         assert any(
             c.args[0] == DECISION_POLL_LATENCY for c in emitter.histogram.call_args_list
@@ -248,15 +211,13 @@ class TestDecisionWorkerPollMetrics:
         client.worker_stub.PollForDecisionTask = AsyncMock(
             side_effect=CadenceRpcError("not found", StatusCode.NOT_FOUND)
         )
-        worker = DecisionWorker(
-            client, TASK_LIST, Registry(), _decision_options(emitter)
-        )
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
         with pytest.raises(CadenceRpcError):
             await worker._poll()
 
         emitter.counter.assert_any_call(
-            DECISION_POLL_FAILED_COUNTER, tags=EXPECTED_TAGS
+            DECISION_POLL_FAILED_COUNTER, 1, tags=EXPECTED_TAGS
         )
 
 
@@ -270,51 +231,23 @@ class TestActivityWorkerRunMetrics:
     async def test_emits_worker_start_counter(self):
         emitter = _mock_emitter()
         worker = ActivityWorker(
-            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
+            _mock_client(), TASK_LIST, Registry(), _worker_options(emitter)
         )
         with patch.object(worker._poller, "run", new=AsyncMock()):
             await worker.run()
 
-        emitter.counter.assert_any_call(WORKER_START_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(WORKER_START_COUNTER, 1, tags=EXPECTED_TAGS)
 
     @pytest.mark.asyncio
     async def test_emits_poller_start_counter_with_configured_count(self):
         emitter = _mock_emitter()
-        options = _decision_options(emitter)
+        options = _worker_options(emitter)
         options["activity_task_pollers"] = 5
         worker = ActivityWorker(_mock_client(), TASK_LIST, Registry(), options)
         with patch.object(worker._poller, "run", new=AsyncMock()):
             await worker.run()
 
         emitter.counter.assert_any_call(POLLER_START_COUNTER, 5, tags=EXPECTED_TAGS)
-
-    @pytest.mark.asyncio
-    async def test_emits_worker_panic_counter_on_exception(self):
-        emitter = _mock_emitter()
-        worker = ActivityWorker(
-            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
-        )
-        with patch.object(
-            worker._poller,
-            "run",
-            new=AsyncMock(side_effect=RuntimeError("unexpected")),
-        ):
-            with pytest.raises(RuntimeError):
-                await worker.run()
-
-        emitter.counter.assert_any_call(WORKER_PANIC_COUNTER, tags=EXPECTED_TAGS)
-
-    @pytest.mark.asyncio
-    async def test_no_panic_counter_on_normal_exit(self):
-        emitter = _mock_emitter()
-        worker = ActivityWorker(
-            _mock_client(), TASK_LIST, Registry(), _decision_options(emitter)
-        )
-        with patch.object(worker._poller, "run", new=AsyncMock()):
-            await worker.run()
-
-        calls = [str(c) for c in emitter.counter.call_args_list]
-        assert not any(WORKER_PANIC_COUNTER in c for c in calls)
 
 
 # ---------------------------------------------------------------------------
@@ -330,16 +263,14 @@ class TestActivityWorkerPollMetrics:
         client.worker_stub.PollForActivityTask = AsyncMock(
             return_value=Mock(task_token=b"")
         )
-        worker = ActivityWorker(
-            client, TASK_LIST, Registry(), _decision_options(emitter)
-        )
+        worker = ActivityWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
         result = await worker._poll()
 
         assert result is None
-        emitter.counter.assert_any_call(ACTIVITY_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(ACTIVITY_POLL_COUNTER, 1, tags=EXPECTED_TAGS)
         emitter.counter.assert_any_call(
-            ACTIVITY_POLL_NO_TASK_COUNTER, tags=EXPECTED_TAGS
+            ACTIVITY_POLL_NO_TASK_COUNTER, 1, tags=EXPECTED_TAGS
         )
         assert any(
             c.args[0] == ACTIVITY_POLL_LATENCY for c in emitter.histogram.call_args_list
@@ -354,16 +285,14 @@ class TestActivityWorkerPollMetrics:
         mock_task.scheduled_time = _make_ts(0)
         mock_task.started_time = _make_ts(0)
         client.worker_stub.PollForActivityTask = AsyncMock(return_value=mock_task)
-        worker = ActivityWorker(
-            client, TASK_LIST, Registry(), _decision_options(emitter)
-        )
+        worker = ActivityWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
         result = await worker._poll()
 
         assert result is mock_task
-        emitter.counter.assert_any_call(ACTIVITY_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(ACTIVITY_POLL_COUNTER, 1, tags=EXPECTED_TAGS)
         emitter.counter.assert_any_call(
-            ACTIVITY_POLL_SUCCEED_COUNTER, tags=EXPECTED_TAGS
+            ACTIVITY_POLL_SUCCEED_COUNTER, 1, tags=EXPECTED_TAGS
         )
 
     @pytest.mark.asyncio
@@ -375,9 +304,7 @@ class TestActivityWorkerPollMetrics:
         mock_task.scheduled_time = _make_ts(500)
         mock_task.started_time = _make_ts(503)
         client.worker_stub.PollForActivityTask = AsyncMock(return_value=mock_task)
-        worker = ActivityWorker(
-            client, TASK_LIST, Registry(), _decision_options(emitter)
-        )
+        worker = ActivityWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
         await worker._poll()
 
@@ -397,16 +324,14 @@ class TestActivityWorkerPollMetrics:
                 "resource exhausted", StatusCode.RESOURCE_EXHAUSTED
             )
         )
-        worker = ActivityWorker(
-            client, TASK_LIST, Registry(), _decision_options(emitter)
-        )
+        worker = ActivityWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
         with pytest.raises(CadenceRpcError):
             await worker._poll()
 
-        emitter.counter.assert_any_call(ACTIVITY_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(ACTIVITY_POLL_COUNTER, 1, tags=EXPECTED_TAGS)
         emitter.counter.assert_any_call(
-            ACTIVITY_POLL_TRANSIENT_FAILED_COUNTER, tags=EXPECTED_TAGS
+            ACTIVITY_POLL_TRANSIENT_FAILED_COUNTER, 1, tags=EXPECTED_TAGS
         )
 
     @pytest.mark.asyncio
@@ -418,13 +343,11 @@ class TestActivityWorkerPollMetrics:
                 "permission denied", StatusCode.PERMISSION_DENIED
             )
         )
-        worker = ActivityWorker(
-            client, TASK_LIST, Registry(), _decision_options(emitter)
-        )
+        worker = ActivityWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
         with pytest.raises(CadenceRpcError):
             await worker._poll()
 
         emitter.counter.assert_any_call(
-            ACTIVITY_POLL_FAILED_COUNTER, tags=EXPECTED_TAGS
+            ACTIVITY_POLL_FAILED_COUNTER, 1, tags=EXPECTED_TAGS
         )

--- a/tests/cadence/worker/test_poll_metrics.py
+++ b/tests/cadence/worker/test_poll_metrics.py
@@ -1,0 +1,377 @@
+"""Tests for poll and worker-start metrics in DecisionWorker and ActivityWorker."""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, PropertyMock
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from cadence.client import Client
+from cadence.error import CadenceRpcError
+from cadence.metrics import MetricsEmitter, NoOpMetricsEmitter
+from cadence.metrics.constants import (
+    ACTIVITY_POLL_COUNTER,
+    ACTIVITY_POLL_FAILED_COUNTER,
+    ACTIVITY_POLL_LATENCY,
+    ACTIVITY_POLL_NO_TASK_COUNTER,
+    ACTIVITY_POLL_SUCCEED_COUNTER,
+    ACTIVITY_POLL_TRANSIENT_FAILED_COUNTER,
+    ACTIVITY_SCHEDULED_TO_START_LATENCY,
+    DECISION_POLL_COUNTER,
+    DECISION_POLL_FAILED_COUNTER,
+    DECISION_POLL_LATENCY,
+    DECISION_POLL_NO_TASK_COUNTER,
+    DECISION_POLL_SUCCEED_COUNTER,
+    DECISION_POLL_TRANSIENT_FAILED_COUNTER,
+    DECISION_SCHEDULED_TO_START_LATENCY,
+    POLLER_START_COUNTER,
+    TAG_DOMAIN,
+    TAG_TASK_LIST,
+    WORKER_PANIC_COUNTER,
+    WORKER_START_COUNTER,
+)
+from cadence.worker._activity import ActivityWorker
+from cadence.worker._decision import DecisionWorker
+from cadence.worker._registry import Registry
+from cadence.worker._types import WorkerOptions
+from grpc import StatusCode
+
+DOMAIN = "test-domain"
+TASK_LIST = "test-tl"
+EXPECTED_TAGS = {TAG_DOMAIN: DOMAIN, TAG_TASK_LIST: TASK_LIST}
+
+
+def _mock_emitter() -> Mock:
+    emitter = Mock(spec=MetricsEmitter)
+    return emitter
+
+
+def _mock_client() -> Mock:
+    client = Mock(spec=Client)
+    type(client).domain = PropertyMock(return_value=DOMAIN)
+    type(client).identity = PropertyMock(return_value="test-identity")
+    client.metrics_emitter = NoOpMetricsEmitter()
+    stub = Mock()
+    stub.PollForDecisionTask = AsyncMock(return_value=Mock(task_token=b""))
+    stub.PollForActivityTask = AsyncMock(return_value=Mock(task_token=b""))
+    client.worker_stub = stub
+    return client
+
+
+def _decision_options(emitter) -> WorkerOptions:
+    return {
+        "identity": "test-id",
+        "metrics_emitter": emitter,
+        "max_concurrent_decision_task_execution_size": 1,
+        "decision_task_pollers": 1,
+        "max_concurrent_activity_execution_size": 1,
+        "activity_task_pollers": 1,
+        "disable_workflow_worker": False,
+        "disable_activity_worker": False,
+    }
+
+
+def _make_ts(seconds: int) -> Timestamp:
+    ts = Timestamp()
+    ts.seconds = seconds
+    return ts
+
+
+# ---------------------------------------------------------------------------
+# DecisionWorker: run() metrics
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionWorkerRunMetrics:
+    @pytest.mark.asyncio
+    async def test_emits_worker_start_counter(self):
+        emitter = _mock_emitter()
+        worker = DecisionWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
+        worker._poller.run = AsyncMock()
+
+        await worker.run()
+
+        emitter.counter.assert_any_call(WORKER_START_COUNTER, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_emits_poller_start_counter_with_configured_count(self):
+        emitter = _mock_emitter()
+        options = _decision_options(emitter)
+        options["decision_task_pollers"] = 3
+        worker = DecisionWorker(_mock_client(), TASK_LIST, Registry(), options)
+        worker._poller.run = AsyncMock()
+
+        await worker.run()
+
+        emitter.counter.assert_any_call(POLLER_START_COUNTER, 3, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_emits_worker_panic_counter_on_exception(self):
+        emitter = _mock_emitter()
+        worker = DecisionWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
+        worker._poller.run = AsyncMock(side_effect=RuntimeError("unexpected"))
+
+        with pytest.raises(RuntimeError):
+            await worker.run()
+
+        emitter.counter.assert_any_call(WORKER_PANIC_COUNTER, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_no_panic_counter_on_normal_exit(self):
+        emitter = _mock_emitter()
+        worker = DecisionWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
+        worker._poller.run = AsyncMock()
+
+        await worker.run()
+
+        calls = [str(c) for c in emitter.counter.call_args_list]
+        assert not any(WORKER_PANIC_COUNTER in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# DecisionWorker: _poll() metrics
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionWorkerPollMetrics:
+    @pytest.mark.asyncio
+    async def test_emits_poll_counter_and_latency_on_empty_response(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        client.worker_stub.PollForDecisionTask = AsyncMock(
+            return_value=Mock(task_token=b"")
+        )
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+
+        result = await worker._poll()
+
+        assert result is None
+        emitter.counter.assert_any_call(DECISION_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(DECISION_POLL_NO_TASK_COUNTER, tags=EXPECTED_TAGS)
+        assert any(
+            c.args[0] == DECISION_POLL_LATENCY for c in emitter.histogram.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_succeed_counter_on_task(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        mock_task = Mock()
+        mock_task.task_token = b"token"
+        mock_task.scheduled_time = _make_ts(0)
+        mock_task.started_time = _make_ts(0)
+        client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+
+        result = await worker._poll()
+
+        assert result is mock_task
+        emitter.counter.assert_any_call(DECISION_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(DECISION_POLL_SUCCEED_COUNTER, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_emits_scheduled_to_start_latency_when_timestamps_set(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        mock_task = Mock()
+        mock_task.task_token = b"token"
+        mock_task.scheduled_time = _make_ts(1000)
+        mock_task.started_time = _make_ts(1002)
+        client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+
+        await worker._poll()
+
+        histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
+        assert DECISION_SCHEDULED_TO_START_LATENCY in histogram_calls
+        latency_call = histogram_calls[DECISION_SCHEDULED_TO_START_LATENCY]
+        assert abs(latency_call.args[1] - 2.0) < 0.01
+
+    @pytest.mark.asyncio
+    async def test_no_scheduled_to_start_when_timestamps_zero(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        mock_task = Mock()
+        mock_task.task_token = b"token"
+        mock_task.scheduled_time = _make_ts(0)
+        mock_task.started_time = _make_ts(0)
+        client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+
+        await worker._poll()
+
+        histogram_names = [c.args[0] for c in emitter.histogram.call_args_list]
+        assert DECISION_SCHEDULED_TO_START_LATENCY not in histogram_names
+
+    @pytest.mark.asyncio
+    async def test_emits_transient_failed_counter_on_retryable_error(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        client.worker_stub.PollForDecisionTask = AsyncMock(
+            side_effect=CadenceRpcError("unavailable", StatusCode.UNAVAILABLE)
+        )
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+
+        with pytest.raises(CadenceRpcError):
+            await worker._poll()
+
+        emitter.counter.assert_any_call(DECISION_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(
+            DECISION_POLL_TRANSIENT_FAILED_COUNTER, tags=EXPECTED_TAGS
+        )
+        assert any(
+            c.args[0] == DECISION_POLL_LATENCY for c in emitter.histogram.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_failed_counter_on_non_retryable_error(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        client.worker_stub.PollForDecisionTask = AsyncMock(
+            side_effect=CadenceRpcError("not found", StatusCode.NOT_FOUND)
+        )
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+
+        with pytest.raises(CadenceRpcError):
+            await worker._poll()
+
+        emitter.counter.assert_any_call(DECISION_POLL_FAILED_COUNTER, tags=EXPECTED_TAGS)
+
+
+# ---------------------------------------------------------------------------
+# ActivityWorker: run() metrics
+# ---------------------------------------------------------------------------
+
+
+class TestActivityWorkerRunMetrics:
+    @pytest.mark.asyncio
+    async def test_emits_worker_start_counter(self):
+        emitter = _mock_emitter()
+        worker = ActivityWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
+        worker._poller.run = AsyncMock()
+
+        await worker.run()
+
+        emitter.counter.assert_any_call(WORKER_START_COUNTER, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_emits_poller_start_counter_with_configured_count(self):
+        emitter = _mock_emitter()
+        options = _decision_options(emitter)
+        options["activity_task_pollers"] = 5
+        worker = ActivityWorker(_mock_client(), TASK_LIST, Registry(), options)
+        worker._poller.run = AsyncMock()
+
+        await worker.run()
+
+        emitter.counter.assert_any_call(POLLER_START_COUNTER, 5, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_emits_worker_panic_counter_on_exception(self):
+        emitter = _mock_emitter()
+        worker = ActivityWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
+        worker._poller.run = AsyncMock(side_effect=RuntimeError("unexpected"))
+
+        with pytest.raises(RuntimeError):
+            await worker.run()
+
+        emitter.counter.assert_any_call(WORKER_PANIC_COUNTER, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_no_panic_counter_on_normal_exit(self):
+        emitter = _mock_emitter()
+        worker = ActivityWorker(_mock_client(), TASK_LIST, Registry(), _decision_options(emitter))
+        worker._poller.run = AsyncMock()
+
+        await worker.run()
+
+        calls = [str(c) for c in emitter.counter.call_args_list]
+        assert not any(WORKER_PANIC_COUNTER in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# ActivityWorker: _poll() metrics
+# ---------------------------------------------------------------------------
+
+
+class TestActivityWorkerPollMetrics:
+    @pytest.mark.asyncio
+    async def test_emits_poll_counter_and_latency_on_empty_response(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        client.worker_stub.PollForActivityTask = AsyncMock(
+            return_value=Mock(task_token=b"")
+        )
+        worker = ActivityWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+
+        result = await worker._poll()
+
+        assert result is None
+        emitter.counter.assert_any_call(ACTIVITY_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(ACTIVITY_POLL_NO_TASK_COUNTER, tags=EXPECTED_TAGS)
+        assert any(
+            c.args[0] == ACTIVITY_POLL_LATENCY for c in emitter.histogram.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_succeed_counter_on_task(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        mock_task = Mock()
+        mock_task.task_token = b"token"
+        mock_task.scheduled_time = _make_ts(0)
+        mock_task.started_time = _make_ts(0)
+        client.worker_stub.PollForActivityTask = AsyncMock(return_value=mock_task)
+        worker = ActivityWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+
+        result = await worker._poll()
+
+        assert result is mock_task
+        emitter.counter.assert_any_call(ACTIVITY_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(ACTIVITY_POLL_SUCCEED_COUNTER, tags=EXPECTED_TAGS)
+
+    @pytest.mark.asyncio
+    async def test_emits_scheduled_to_start_latency_when_timestamps_set(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        mock_task = Mock()
+        mock_task.task_token = b"token"
+        mock_task.scheduled_time = _make_ts(500)
+        mock_task.started_time = _make_ts(503)
+        client.worker_stub.PollForActivityTask = AsyncMock(return_value=mock_task)
+        worker = ActivityWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+
+        await worker._poll()
+
+        histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
+        assert ACTIVITY_SCHEDULED_TO_START_LATENCY in histogram_calls
+        assert abs(histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] - 3.0) < 0.01
+
+    @pytest.mark.asyncio
+    async def test_emits_transient_failed_counter_on_retryable_error(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        client.worker_stub.PollForActivityTask = AsyncMock(
+            side_effect=CadenceRpcError("resource exhausted", StatusCode.RESOURCE_EXHAUSTED)
+        )
+        worker = ActivityWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+
+        with pytest.raises(CadenceRpcError):
+            await worker._poll()
+
+        emitter.counter.assert_any_call(ACTIVITY_POLL_COUNTER, tags=EXPECTED_TAGS)
+        emitter.counter.assert_any_call(
+            ACTIVITY_POLL_TRANSIENT_FAILED_COUNTER, tags=EXPECTED_TAGS
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_failed_counter_on_non_retryable_error(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        client.worker_stub.PollForActivityTask = AsyncMock(
+            side_effect=CadenceRpcError("permission denied", StatusCode.PERMISSION_DENIED)
+        )
+        worker = ActivityWorker(client, TASK_LIST, Registry(), _decision_options(emitter))
+
+        with pytest.raises(CadenceRpcError):
+            await worker._poll()
+
+        emitter.counter.assert_any_call(ACTIVITY_POLL_FAILED_COUNTER, tags=EXPECTED_TAGS)

--- a/tests/cadence/worker/test_poller.py
+++ b/tests/cadence/worker/test_poller.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -66,6 +67,25 @@ async def test_poller_num_tasks():
     assert outgoing.empty() is True
 
     task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_poller_emits_start_callback_with_num_tasks():
+    permits = asyncio.Semaphore(1)
+
+    async def poll_func() -> str | None:
+        return None
+
+    async def callback(_: str) -> None:
+        return None
+
+    on_start = Mock()
+    poller = Poller(3, permits, poll_func, callback, on_start=on_start)
+
+    with patch.object(poller, "_poll_loop", new_callable=AsyncMock):
+        await poller.run()
+
+    on_start.assert_called_once_with(3)
 
 
 @pytest.mark.asyncio

--- a/tests/integration_tests/docker-compose.yml
+++ b/tests/integration_tests/docker-compose.yml
@@ -53,6 +53,21 @@ services:
       services-network:
         aliases:
           - cadence-web
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    ports:
+      - "9090:9090"
+    volumes:
+      - "./prometheus.yml:/etc/prometheus/prometheus.yml:ro"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      services-network:
+        aliases:
+          - prometheus
 networks:
   services-network:
     name: services-network

--- a/tests/integration_tests/prometheus.yml
+++ b/tests/integration_tests/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 1s
+  evaluation_interval: 1s
+
+scrape_configs:
+  - job_name: cadence-python-client
+    static_configs:
+      - targets:
+          - host.docker.internal:9108

--- a/tests/integration_tests/test_prometheus_metrics.py
+++ b/tests/integration_tests/test_prometheus_metrics.py
@@ -1,0 +1,163 @@
+import asyncio
+import threading
+from contextlib import contextmanager
+from datetime import timedelta
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Iterator
+from urllib.parse import urlencode
+from urllib.request import urlopen
+import json
+
+from prometheus_client import CollectorRegistry
+from pytest_docker import Services
+
+from cadence import Registry, activity, workflow
+from cadence.api.v1.history_pb2 import EventFilterType
+from cadence.api.v1.service_workflow_pb2 import (
+    GetWorkflowExecutionHistoryRequest,
+    GetWorkflowExecutionHistoryResponse,
+)
+from cadence.metrics import PrometheusConfig, PrometheusMetrics
+from tests.integration_tests.helper import CadenceHelper, DOMAIN_NAME
+
+
+PROMETHEUS_SCRAPE_PORT = 9108
+
+registry = Registry()
+
+
+@registry.activity()
+async def echo_for_metrics(message: str) -> str:
+    return message
+
+
+@registry.workflow()
+class WorkflowWithMetrics:
+    @workflow.run
+    async def run(self, message: str) -> str:
+        return await echo_for_metrics.with_options(
+            schedule_to_close_timeout=timedelta(seconds=10)
+        ).execute(message)
+
+
+@contextmanager
+def metrics_endpoint(metrics: PrometheusMetrics) -> Iterator[None]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path != "/metrics":
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            body = metrics.get_metrics_text().encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: Any) -> None:
+            pass
+
+    server = ThreadingHTTPServer(("0.0.0.0", PROMETHEUS_SCRAPE_PORT), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _get_json(url: str) -> dict[str, Any]:
+    with urlopen(url, timeout=5) as response:
+        return json.loads(response.read().decode())
+
+
+def _get_text(url: str) -> str:
+    with urlopen(url, timeout=5) as response:
+        return response.read().decode()
+
+
+async def _query_prometheus(prometheus_url: str, query: str) -> dict[str, Any]:
+    params = urlencode({"query": query})
+    return await asyncio.to_thread(
+        _get_json, f"{prometheus_url}/api/v1/query?{params}"
+    )
+
+
+async def _wait_for_prometheus_metric(prometheus_url: str, query: str) -> None:
+    deadline = asyncio.get_running_loop().time() + 30
+    last_response: dict[str, Any] | None = None
+
+    while asyncio.get_running_loop().time() < deadline:
+        last_response = await _query_prometheus(prometheus_url, query)
+        results = last_response.get("data", {}).get("result", [])
+        if results:
+            value = float(results[0]["value"][1])
+            if value > 0:
+                return
+        await asyncio.sleep(1)
+
+    raise AssertionError(f"Prometheus did not scrape {query}: {last_response}")
+
+
+async def test_worker_poll_metrics_are_scraped_by_prometheus(
+    helper: CadenceHelper, docker_ip: str, docker_services: Services
+):
+    prometheus_url = f"http://{docker_ip}:{docker_services.port_for('prometheus', 9090)}"
+    docker_services.wait_until_responsive(
+        timeout=30,
+        pause=1,
+        check=lambda: "Prometheus Server is Ready"
+        in _get_text(f"{prometheus_url}/-/ready"),
+    )
+
+    metrics = PrometheusMetrics(PrometheusConfig(registry=CollectorRegistry()))
+    task_list = helper.test_name
+
+    with metrics_endpoint(metrics):
+        async with helper.worker(
+            registry,
+            metrics_emitter=metrics,
+            activity_task_pollers=1,
+            decision_task_pollers=1,
+        ) as worker:
+            execution = await worker.client.start_workflow(
+                "WorkflowWithMetrics",
+                "hello metrics",
+                task_list=worker.task_list,
+                execution_start_to_close_timeout=timedelta(seconds=10),
+            )
+
+            response: GetWorkflowExecutionHistoryResponse = await worker.client.workflow_stub.GetWorkflowExecutionHistory(
+                GetWorkflowExecutionHistoryRequest(
+                    domain=DOMAIN_NAME,
+                    workflow_execution=execution,
+                    wait_for_new_event=True,
+                    history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_CLOSE_EVENT,
+                    skip_archival=True,
+                )
+            )
+
+            assert (
+                '"hello metrics"'
+                == response.history.events[
+                    -1
+                ].workflow_execution_completed_event_attributes.result.data.decode()
+            )
+
+        labels = f'{{Domain="{DOMAIN_NAME}",TaskList="{task_list}"}}'
+        await _wait_for_prometheus_metric(
+            prometheus_url, f"cadence_worker_start_total{labels}"
+        )
+        await _wait_for_prometheus_metric(
+            prometheus_url, f"cadence_poller_start_total{labels}"
+        )
+        await _wait_for_prometheus_metric(
+            prometheus_url, f"cadence_decision_poll_succeed_total{labels}"
+        )
+        await _wait_for_prometheus_metric(
+            prometheus_url, f"cadence_activity_poll_succeed_total{labels}"
+        )

--- a/tests/integration_tests/test_prometheus_metrics.py
+++ b/tests/integration_tests/test_prometheus_metrics.py
@@ -3,7 +3,7 @@ import threading
 from contextlib import contextmanager
 from datetime import timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, Iterator
+from typing import Any, Iterator, cast
 from urllib.parse import urlencode
 from urllib.request import urlopen
 import json
@@ -11,7 +11,7 @@ import json
 from prometheus_client import CollectorRegistry
 from pytest_docker import Services
 
-from cadence import Registry, activity, workflow
+from cadence import Registry, workflow
 from cadence.api.v1.history_pb2 import EventFilterType
 from cadence.api.v1.service_workflow_pb2 import (
     GetWorkflowExecutionHistoryRequest,
@@ -72,19 +72,17 @@ def metrics_endpoint(metrics: PrometheusMetrics) -> Iterator[None]:
 
 def _get_json(url: str) -> dict[str, Any]:
     with urlopen(url, timeout=5) as response:
-        return json.loads(response.read().decode())
+        return cast(dict[str, Any], json.loads(response.read().decode()))
 
 
 def _get_text(url: str) -> str:
     with urlopen(url, timeout=5) as response:
-        return response.read().decode()
+        return cast(str, response.read().decode())
 
 
 async def _query_prometheus(prometheus_url: str, query: str) -> dict[str, Any]:
     params = urlencode({"query": query})
-    return await asyncio.to_thread(
-        _get_json, f"{prometheus_url}/api/v1/query?{params}"
-    )
+    return await asyncio.to_thread(_get_json, f"{prometheus_url}/api/v1/query?{params}")
 
 
 async def _wait_for_prometheus_metric(prometheus_url: str, query: str) -> None:
@@ -106,12 +104,15 @@ async def _wait_for_prometheus_metric(prometheus_url: str, query: str) -> None:
 async def test_worker_poll_metrics_are_scraped_by_prometheus(
     helper: CadenceHelper, docker_ip: str, docker_services: Services
 ):
-    prometheus_url = f"http://{docker_ip}:{docker_services.port_for('prometheus', 9090)}"
+    prometheus_url = (
+        f"http://{docker_ip}:{docker_services.port_for('prometheus', 9090)}"
+    )
     docker_services.wait_until_responsive(
         timeout=30,
         pause=1,
-        check=lambda: "Prometheus Server is Ready"
-        in _get_text(f"{prometheus_url}/-/ready"),
+        check=lambda: (
+            "Prometheus Server is Ready" in _get_text(f"{prometheus_url}/-/ready")
+        ),
     )
 
     metrics = PrometheusMetrics(PrometheusConfig(registry=CollectorRegistry()))

--- a/tests/integration_tests/test_prometheus_metrics.py
+++ b/tests/integration_tests/test_prometheus_metrics.py
@@ -1,14 +1,12 @@
 import asyncio
-import threading
 from contextlib import contextmanager
 from datetime import timedelta
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Iterator, cast
 from urllib.parse import urlencode
 from urllib.request import urlopen
 import json
 
-from prometheus_client import CollectorRegistry
+from prometheus_client import CollectorRegistry, start_http_server
 from pytest_docker import Services
 
 from cadence import Registry, workflow
@@ -42,26 +40,10 @@ class WorkflowWithMetrics:
 
 @contextmanager
 def metrics_endpoint(metrics: PrometheusMetrics) -> Iterator[None]:
-    class Handler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:
-            if self.path != "/metrics":
-                self.send_response(404)
-                self.end_headers()
-                return
-
-            body = metrics.get_metrics_text().encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "text/plain; version=0.0.4")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-
-        def log_message(self, format: str, *args: Any) -> None:
-            pass
-
-    server = ThreadingHTTPServer(("0.0.0.0", PROMETHEUS_SCRAPE_PORT), Handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
+    server, thread = start_http_server(
+        PROMETHEUS_SCRAPE_PORT,
+        registry=metrics.registry,
+    )
     try:
         yield
     finally:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Workers now report **metrics** when they poll Cadence for work and when they start or stop unexpectedly.

- Each **long poll** can increment counters and record how long the poll took. You can see polls that returned a task, polls that returned nothing, and polls that failed (including “might retry” vs “probably won’t”).
- When a task is returned, we can also record **how long the task waited** between being scheduled and starting (when the server gives us the timestamps).
- When the worker process starts its polling loop, we record **worker started** and **pollers started** (one “poller start” per configured poller).
- If the polling loop exits because of an uncaught error, we record a **worker panic** counter.


<!-- Tell your future self why have you made these changes -->
**Why?**

So people running the Python client can **see what the worker is doing** in dashboards and alerts—similar to other Cadence SDKs—without digging through logs.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**


<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
