### PR TITLE
feat(metrics): configure Prometheus duration buckets

### DIFF
--- a/cadence/metrics/__init__.py
+++ b/cadence/metrics/__init__.py
@@ -6,10 +6,22 @@ from .metrics import (
     NoOpMetricsEmitter,
     MetricType,
 )
+from .histogram_buckets import (
+    DEFAULT_1MS_100S,
+    HIGH_1MS_24H,
+    LOW_1MS_100S,
+    MID_1MS_24H,
+    default_buckets_for_metric,
+)
 from .prometheus import PrometheusMetrics, PrometheusConfig
 
 __all__ = [
     "duration_between_ns",
+    "DEFAULT_1MS_100S",
+    "HIGH_1MS_24H",
+    "LOW_1MS_100S",
+    "MID_1MS_24H",
+    "default_buckets_for_metric",
     "MetricsEmitter",
     "NoOpMetricsEmitter",
     "MetricType",

--- a/cadence/metrics/__init__.py
+++ b/cadence/metrics/__init__.py
@@ -1,9 +1,15 @@
 """Metrics collection components for Cadence client."""
 
-from .metrics import MetricsEmitter, NoOpMetricsEmitter, MetricType
+from .metrics import (
+    duration_between_ns,
+    MetricsEmitter,
+    NoOpMetricsEmitter,
+    MetricType,
+)
 from .prometheus import PrometheusMetrics, PrometheusConfig
 
 __all__ = [
+    "duration_between_ns",
     "MetricsEmitter",
     "NoOpMetricsEmitter",
     "MetricType",

--- a/cadence/metrics/__init__.py
+++ b/cadence/metrics/__init__.py
@@ -1,9 +1,21 @@
 """Metrics collection components for Cadence client."""
 
+from .histogram_buckets import (
+    DEFAULT_1MS_100S,
+    HIGH_1MS_24H,
+    LOW_1MS_100S,
+    MID_1MS_24H,
+    default_buckets_for_metric,
+)
 from .metrics import MetricsEmitter, NoOpMetricsEmitter, MetricType
 from .prometheus import PrometheusMetrics, PrometheusConfig
 
 __all__ = [
+    "DEFAULT_1MS_100S",
+    "HIGH_1MS_24H",
+    "LOW_1MS_100S",
+    "MID_1MS_24H",
+    "default_buckets_for_metric",
     "MetricsEmitter",
     "NoOpMetricsEmitter",
     "MetricType",

--- a/cadence/metrics/histogram_buckets.py
+++ b/cadence/metrics/histogram_buckets.py
@@ -1,0 +1,91 @@
+"""Nanosecond histogram bucket boundaries for SDK duration metrics.
+
+Ported from the Go and Java Cadence SDKs so that histograms recorded by this
+client line up with the same client-side latency dashboards/alerts:
+
+  - Go SDK:   internal/common/metrics/histograms.go, generates the boundaries
+    algorithmically as an OTel-style exponential histogram.
+    https://github.com/cadence-workflow/cadence-go-client/pull/1489
+  - Java SDK: internal/metrics/HistogramBuckets.java, enumerates the same
+    boundaries explicitly rather than generating them.
+    https://github.com/cadence-workflow/cadence-java-client/pull/1048
+
+This module follows the Java SDK's approach (explicit values) since Python has
+no equivalent of the Go client's exponential-histogram builder to port.
+"""
+
+from typing import Callable, Sequence, Tuple
+
+_NS_PER_MS = 1_000_000
+_NS_PER_S = 1_000_000_000
+_NS_PER_MIN = 60 * _NS_PER_S
+_NS_PER_HOUR = 60 * _NS_PER_MIN
+
+
+def _ms(*values: int) -> Tuple[int, ...]:
+    return tuple(v * _NS_PER_MS for v in values)
+
+
+def _s(*values: int) -> Tuple[int, ...]:
+    return tuple(v * _NS_PER_S for v in values)
+
+
+def _min(*values: int) -> Tuple[int, ...]:
+    return tuple(v * _NS_PER_MIN for v in values)
+
+
+def _h(*values: int) -> Tuple[int, ...]:
+    return tuple(v * _NS_PER_HOUR for v in values)
+
+
+# Default bucket configuration for most client-side latency metrics.
+# Range: 1ms - 100s. 46 buckets.
+# Use for: poll latency, execution latency, response latency, scheduled-to-start
+# latency, and most other RPC call latencies.
+DEFAULT_1MS_100S: Tuple[int, ...] = (
+    *_ms(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100),
+    *_ms(200, 300, 400, 500, 600, 700, 800, 900),
+    *_s(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100),
+)
+
+# Low-resolution version of DEFAULT_1MS_100S for high-cardinality metrics
+# (e.g. per-activity-type or per-workflow-type tags). Range: 1ms - 100s. 16 buckets.
+LOW_1MS_100S: Tuple[int, ...] = (
+    *_ms(1, 2, 5, 10, 20, 50, 100, 200, 500),
+    *_s(1, 2, 5, 10, 20, 50, 100),
+)
+
+# Bucket configuration for long-running operations. Range: 1ms - 24h. 27 buckets.
+# Use for: workflow end-to-end latency, long-running activity execution latency.
+HIGH_1MS_24H: Tuple[int, ...] = (
+    *_ms(1, 2, 5, 10, 20, 50, 100, 200, 500),
+    *_s(1, 2, 5, 10, 20, 30, 60, 120, 300, 600),
+    *_min(20, 30),
+    *_h(1, 2, 4, 8, 12, 24),
+)
+
+# Low-resolution version of HIGH_1MS_24H for high-cardinality long-running
+# metrics (e.g. per-workflow-type end-to-end latency). Range: 1ms - 24h. 14 buckets.
+MID_1MS_24H: Tuple[int, ...] = (
+    *_ms(1, 10, 100),
+    *_s(1, 10, 30),
+    *_min(1, 5, 10, 30),
+    *_h(1, 4, 12, 24),
+)
+
+DurationBucketResolver = Callable[[str], Sequence[int]]
+
+
+def default_buckets_for_metric(metric_name: str) -> Tuple[int, ...]:
+    """Pick a default bucket set for a `_ns`-suffixed duration metric name.
+
+    Mirrors the Go/Java SDKs' own default selection: end-to-end latency metrics
+    (typically long-running) get the wider 1ms-24h range, everything else uses
+    the 1ms-100s range. Pass a different callable as
+    ``PrometheusConfig.duration_bucket_resolver`` to change this, or set
+    ``PrometheusConfig.histogram_buckets[metric_name]`` to override a single
+    metric.
+    """
+    if "endtoend" in metric_name:
+        return HIGH_1MS_24H
+    return DEFAULT_1MS_100S

--- a/cadence/metrics/metrics.py
+++ b/cadence/metrics/metrics.py
@@ -4,7 +4,11 @@ import logging
 from enum import Enum
 from typing import Dict, Optional, Protocol
 
+from google.protobuf.timestamp_pb2 import Timestamp
+
 logger = logging.getLogger(__name__)
+
+_NANOSECONDS_PER_SECOND = 1_000_000_000
 
 
 class MetricType(Enum):
@@ -37,6 +41,22 @@ class MetricsEmitter(Protocol):
     ) -> None:
         """Send a histogram metric."""
         ...
+
+
+def duration_between_ns(start: Timestamp, end: Timestamp) -> Optional[int]:
+    """Return a non-negative duration in nanoseconds between two set timestamps."""
+    if not _timestamp_is_set(start) or not _timestamp_is_set(end):
+        return None
+    duration = (
+        (end.seconds - start.seconds) * _NANOSECONDS_PER_SECOND
+        + end.nanos
+        - start.nanos
+    )
+    return max(0, int(duration))
+
+
+def _timestamp_is_set(timestamp: Timestamp) -> bool:
+    return bool(timestamp.seconds or timestamp.nanos)
 
 
 class _TaggedEmitter:

--- a/cadence/metrics/prometheus.py
+++ b/cadence/metrics/prometheus.py
@@ -2,7 +2,7 @@
 
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence
 
 from prometheus_client import (  # type: ignore[import-not-found]
     REGISTRY,
@@ -13,6 +13,7 @@ from prometheus_client import (  # type: ignore[import-not-found]
     generate_latest,
 )
 
+from .histogram_buckets import DurationBucketResolver, default_buckets_for_metric
 from .metrics import MetricsEmitter, _TaggedEmitter
 
 
@@ -28,6 +29,15 @@ class PrometheusConfig:
 
     # Custom registry (if None, uses default global registry)
     registry: Optional[CollectorRegistry] = None
+
+    # Per-metric bucket overrides, keyed by exact metric name (e.g.
+    # "cadence-activity-execution-latency_ns"). Takes precedence over
+    # duration_bucket_resolver and the built-in Go/Java-aligned defaults.
+    histogram_buckets: Dict[str, Sequence[float]] = field(default_factory=dict)
+
+    # Overrides how default buckets are chosen for any `_ns`-suffixed metric not
+    # covered by histogram_buckets. Defaults to histogram_buckets.default_buckets_for_metric.
+    duration_bucket_resolver: Optional[DurationBucketResolver] = None
 
 
 class PrometheusMetrics(MetricsEmitter):
@@ -97,17 +107,40 @@ class PrometheusMetrics(MetricsEmitter):
 
         if metric_name not in self._histograms:
             label_names = list(self._merge_labels(labels).keys()) if labels else []
-            # Current histogram uses the prometheus_client default buckets; aligning
-            # bucket definitions with the Go SDK is planned for a later PR.
-            self._histograms[metric_name] = Histogram(
-                metric_name,
-                f"Histogram metric for {name}",
-                labelnames=label_names,
-                registry=self.registry,
-            )
+            buckets = self._resolve_buckets(metric_name)
+            if buckets is not None:
+                histogram = Histogram(
+                    metric_name,
+                    f"Histogram metric for {name}",
+                    labelnames=label_names,
+                    registry=self.registry,
+                    buckets=tuple(buckets),
+                )
+            else:
+                histogram = Histogram(
+                    metric_name,
+                    f"Histogram metric for {name}",
+                    labelnames=label_names,
+                    registry=self.registry,
+                )
+            self._histograms[metric_name] = histogram
             logger.debug(f"Created histogram metric: {metric_name}")
 
         return self._histograms[metric_name]
+
+    def _resolve_buckets(self, metric_name: str) -> Optional[Sequence[float]]:
+        """Resolve bucket boundaries for a histogram, or None for Prometheus's defaults.
+
+        Precedence: per-metric override, then custom resolver, then Go/Java-aligned
+        defaults for `_ns` metrics, then Prometheus's own defaults otherwise.
+        """
+        override = self.config.histogram_buckets.get(metric_name)
+        if override is not None:
+            return override
+        if not metric_name.endswith("_ns"):
+            return None
+        resolver = self.config.duration_bucket_resolver or default_buckets_for_metric
+        return resolver(metric_name)
 
     def with_tags(self, tags: Dict[str, str]) -> "MetricsEmitter":
         return _TaggedEmitter(self, tags)

--- a/cadence/worker/_activity.py
+++ b/cadence/worker/_activity.py
@@ -81,7 +81,7 @@ class ActivityWorker:
             raise
 
     async def _poll(self) -> Optional[PollForActivityTaskResponse]:
-        async with self._poll_metrics.track() as start:
+        async with self._poll_metrics.track():
             task: PollForActivityTaskResponse = (
                 await self._client.worker_stub.PollForActivityTask(
                     PollForActivityTaskRequest(
@@ -95,7 +95,7 @@ class ActivityWorker:
                     timeout=_LONG_POLL_TIMEOUT,
                 )
             )
-            self._poll_metrics.record_result(start, task)
+            self._poll_metrics.record_result(task)
             return task if task.task_token else None
 
     async def _execute(self, task: PollForActivityTaskResponse) -> None:

--- a/cadence/worker/_decision.py
+++ b/cadence/worker/_decision.py
@@ -82,7 +82,7 @@ class DecisionWorker:
             raise
 
     async def _poll(self) -> Optional[PollForDecisionTaskResponse]:
-        async with self._poll_metrics.track() as start:
+        async with self._poll_metrics.track():
             task: PollForDecisionTaskResponse = (
                 await self._client.worker_stub.PollForDecisionTask(
                     PollForDecisionTaskRequest(
@@ -96,7 +96,7 @@ class DecisionWorker:
                     timeout=_LONG_POLL_TIMEOUT,
                 )
             )
-            self._poll_metrics.record_result(start, task)
+            self._poll_metrics.record_result(task)
             return task if (task and task.task_token) else None
 
     async def _execute(self, task: PollForDecisionTaskResponse) -> None:

--- a/cadence/worker/_poll_metrics.py
+++ b/cadence/worker/_poll_metrics.py
@@ -10,7 +10,10 @@ from google.protobuf import timestamp_pb2
 
 from cadence._internal.rpc.retry import RETRYABLE_CODES
 from cadence.error import CadenceRpcError
-from cadence.metrics import MetricsEmitter
+from cadence.metrics import (
+    duration_between_ns,
+    MetricsEmitter,
+)
 
 
 class PollTask(Protocol):
@@ -31,29 +34,28 @@ class PollMetrics:
     scheduled_to_start: str
 
     @contextlib.asynccontextmanager
-    async def track(self) -> AsyncIterator[float]:
+    async def track(self) -> AsyncIterator[None]:
         """Emit poll counter; guarantee exactly one outcome counter on error."""
         self.emitter.counter(self.poll)
-        start = time.monotonic()
+        start = time.monotonic_ns()
         try:
-            yield start
+            yield
         except CadenceRpcError as e:
-            self.emitter.histogram(self.latency, time.monotonic() - start)
             metric = self.transient_failed if e.code in RETRYABLE_CODES else self.failed
             self.emitter.counter(metric)
             raise
         except Exception:
             self.emitter.counter(self.failed)
             raise
+        finally:
+            self.emitter.histogram(self.latency, time.monotonic_ns() - start)
 
-    def record_result(self, start: float, task: PollTask) -> None:
-        """Record latency, then succeed vs idle, and optional schedule-to-start lag."""
-        self.emitter.histogram(self.latency, time.monotonic() - start)
+    def record_result(self, task: PollTask) -> None:
+        """Record succeed vs idle and optional schedule-to-start latency."""
         if not (task and task.task_token):
             self.emitter.counter(self.no_task)
             return
         self.emitter.counter(self.succeed)
-        s, e = task.scheduled_time, task.started_time
-        if (s.seconds or s.nanos) and (e.seconds or e.nanos):
-            lag = (e.ToDatetime() - s.ToDatetime()).total_seconds()
-            self.emitter.histogram(self.scheduled_to_start, max(0.0, lag))
+        latency_ns = duration_between_ns(task.scheduled_time, task.started_time)
+        if latency_ns is not None:
+            self.emitter.histogram(self.scheduled_to_start, latency_ns)

--- a/tests/cadence/metrics/test_metrics.py
+++ b/tests/cadence/metrics/test_metrics.py
@@ -2,12 +2,18 @@
 
 from unittest.mock import Mock
 
+from google.protobuf.timestamp_pb2 import Timestamp
 
 from cadence.metrics import (
+    duration_between_ns,
     MetricsEmitter,
     MetricType,
     NoOpMetricsEmitter,
 )
+
+
+def _timestamp(seconds: int = 0, nanos: int = 0) -> Timestamp:
+    return Timestamp(seconds=seconds, nanos=nanos)
 
 
 class TestMetricsEmitter:
@@ -51,3 +57,27 @@ class TestMetricType:
         assert MetricType.COUNTER.value == "counter"
         assert MetricType.GAUGE.value == "gauge"
         assert MetricType.HISTOGRAM.value == "histogram"
+
+
+class TestDurationMetrics:
+    def test_duration_between_ns_set_timestamps(self):
+        assert (
+            duration_between_ns(
+                _timestamp(seconds=10, nanos=100_000_000),
+                _timestamp(seconds=12, nanos=350_000_000),
+            )
+            == 2_250_000_000
+        )
+
+    def test_duration_between_ns_requires_both_timestamps(self):
+        assert duration_between_ns(_timestamp(), _timestamp(seconds=1)) is None
+        assert duration_between_ns(_timestamp(seconds=1), _timestamp()) is None
+
+    def test_duration_between_ns_clamps_clock_skew(self):
+        assert (
+            duration_between_ns(
+                _timestamp(seconds=2),
+                _timestamp(seconds=1),
+            )
+            == 0
+        )

--- a/tests/cadence/metrics/test_prometheus.py
+++ b/tests/cadence/metrics/test_prometheus.py
@@ -108,18 +108,14 @@ class TestPrometheusMetrics:
 
         metrics.histogram("cadence-workflow-endtoend-latency_ns", 1_000_000_000)
 
-        assert mock_histogram_class.call_args.kwargs["buckets"] == tuple(
-            HIGH_1MS_24H
-        )
+        assert mock_histogram_class.call_args.kwargs["buckets"] == tuple(HIGH_1MS_24H)
 
     @patch("cadence.metrics.prometheus.Histogram")
     def test_histogram_buckets_override_by_exact_metric_name(
         self, mock_histogram_class
     ):
         custom_buckets = (1.0, 2.0, 3.0)
-        config = PrometheusConfig(
-            histogram_buckets={"test_latency_ns": custom_buckets}
-        )
+        config = PrometheusConfig(histogram_buckets={"test_latency_ns": custom_buckets})
         metrics = PrometheusMetrics(config)
 
         metrics.histogram("test_latency_ns", 1_000_000_000)
@@ -128,7 +124,7 @@ class TestPrometheusMetrics:
 
     @patch("cadence.metrics.prometheus.Histogram")
     def test_duration_bucket_resolver_override(self, mock_histogram_class):
-        custom_buckets = (5.0, 10.0)
+        custom_buckets = (5, 10)
         config = PrometheusConfig(duration_bucket_resolver=lambda name: custom_buckets)
         metrics = PrometheusMetrics(config)
 

--- a/tests/cadence/metrics/test_prometheus.py
+++ b/tests/cadence/metrics/test_prometheus.py
@@ -3,9 +3,11 @@
 from unittest.mock import Mock, patch
 
 from cadence.metrics import (
+    HIGH_1MS_24H,
     PrometheusMetrics,
     PrometheusConfig,
 )
+from cadence.metrics.histogram_buckets import DEFAULT_1MS_100S
 
 
 class TestPrometheusConfig:
@@ -85,6 +87,54 @@ class TestPrometheusMetrics:
         mock_histogram_class.assert_called_once()
         mock_histogram.labels.assert_called_once_with(type="latency")
         mock_histogram.labels.return_value.observe.assert_called_once_with(1.5)
+
+    @patch("cadence.metrics.prometheus.Histogram")
+    def test_duration_histogram_uses_default_1ms_100s_buckets(
+        self, mock_histogram_class
+    ):
+        metrics = PrometheusMetrics()
+
+        metrics.histogram("test_latency_ns", 1_000_000_000)
+
+        assert mock_histogram_class.call_args.kwargs["buckets"] == tuple(
+            DEFAULT_1MS_100S
+        )
+
+    @patch("cadence.metrics.prometheus.Histogram")
+    def test_endtoend_duration_histogram_uses_high_24h_buckets(
+        self, mock_histogram_class
+    ):
+        metrics = PrometheusMetrics()
+
+        metrics.histogram("cadence-workflow-endtoend-latency_ns", 1_000_000_000)
+
+        assert mock_histogram_class.call_args.kwargs["buckets"] == tuple(
+            HIGH_1MS_24H
+        )
+
+    @patch("cadence.metrics.prometheus.Histogram")
+    def test_histogram_buckets_override_by_exact_metric_name(
+        self, mock_histogram_class
+    ):
+        custom_buckets = (1.0, 2.0, 3.0)
+        config = PrometheusConfig(
+            histogram_buckets={"test_latency_ns": custom_buckets}
+        )
+        metrics = PrometheusMetrics(config)
+
+        metrics.histogram("test_latency_ns", 1_000_000_000)
+
+        assert mock_histogram_class.call_args.kwargs["buckets"] == custom_buckets
+
+    @patch("cadence.metrics.prometheus.Histogram")
+    def test_duration_bucket_resolver_override(self, mock_histogram_class):
+        custom_buckets = (5.0, 10.0)
+        config = PrometheusConfig(duration_bucket_resolver=lambda name: custom_buckets)
+        metrics = PrometheusMetrics(config)
+
+        metrics.histogram("test_latency_ns", 1_000_000_000)
+
+        assert mock_histogram_class.call_args.kwargs["buckets"] == custom_buckets
 
     def test_metric_name_generation(self):
         """Test metric name generation."""

--- a/tests/cadence/worker/test_poll_metrics.py
+++ b/tests/cadence/worker/test_poll_metrics.py
@@ -200,7 +200,7 @@ class TestDecisionWorkerPollMetrics:
         histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
         assert DECISION_SCHEDULED_TO_START_LATENCY in histogram_calls
         latency_call = histogram_calls[DECISION_SCHEDULED_TO_START_LATENCY]
-        assert abs(latency_call.args[1] - 2.0) < 0.01
+        assert latency_call.args[1] == 2_000_000_000
 
     @pytest.mark.asyncio
     async def test_no_scheduled_to_start_when_timestamps_zero(self):
@@ -268,6 +268,23 @@ class TestDecisionWorkerPollMetrics:
 
         emitter.counter.assert_any_call(
             DECISION_POLL_FAILED_COUNTER, 1, tags=EXPECTED_TAGS
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_latency_on_unexpected_error(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        client.worker_stub.PollForDecisionTask = AsyncMock(
+            side_effect=RuntimeError("unexpected")
+        )
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
+
+        with pytest.raises(RuntimeError, match="unexpected"):
+            await worker._poll()
+
+        assert any(
+            call.args[0] == DECISION_POLL_LATENCY
+            for call in emitter.histogram.call_args_list
         )
 
 
@@ -393,8 +410,8 @@ class TestActivityWorkerPollMetrics:
         histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
         assert ACTIVITY_SCHEDULED_TO_START_LATENCY in histogram_calls
         assert (
-            abs(histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] - 3.0)
-            < 0.01
+            histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1]
+            == 3_000_000_000
         )
 
     @pytest.mark.asyncio
@@ -412,8 +429,7 @@ class TestActivityWorkerPollMetrics:
 
         histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
         assert (
-            abs(histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] - 0.2)
-            < 0.01
+            histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] == 200_000_000
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added SDK-aligned histogram bucket definitions for duration metrics and applied them to Prometheus histograms, with support for per-metric overrides and custom bucket resolution.


<!-- Tell your future self why have you made these changes -->
**Why?**
Histogram buckets previously used Prometheus defaults, which didn’t match other Cadence SDKs. This keeps latency metrics consistent across clients for shared dashboards and alerts.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**