### PR TITLE
feat(metrics): add duration timing helper methods

### DIFF
--- a/cadence/metrics/__init__.py
+++ b/cadence/metrics/__init__.py
@@ -1,12 +1,22 @@
 """Metrics collection components for Cadence client."""
 
-from .metrics import MetricsEmitter, NoOpMetricsEmitter, MetricType
+from .metrics import (
+    duration_between_ns,
+    MetricsEmitter,
+    MetricsStopwatch,
+    NoOpMetricsEmitter,
+    MetricType,
+    record_duration,
+)
 from .prometheus import PrometheusMetrics, PrometheusConfig
 
 __all__ = [
+    "duration_between_ns",
     "MetricsEmitter",
+    "MetricsStopwatch",
     "NoOpMetricsEmitter",
     "MetricType",
     "PrometheusMetrics",
     "PrometheusConfig",
+    "record_duration",
 ]

--- a/cadence/metrics/__init__.py
+++ b/cadence/metrics/__init__.py
@@ -3,20 +3,16 @@
 from .metrics import (
     duration_between_ns,
     MetricsEmitter,
-    MetricsStopwatch,
     NoOpMetricsEmitter,
     MetricType,
-    record_duration,
 )
 from .prometheus import PrometheusMetrics, PrometheusConfig
 
 __all__ = [
     "duration_between_ns",
     "MetricsEmitter",
-    "MetricsStopwatch",
     "NoOpMetricsEmitter",
     "MetricType",
     "PrometheusMetrics",
     "PrometheusConfig",
-    "record_duration",
 ]

--- a/cadence/metrics/metrics.py
+++ b/cadence/metrics/metrics.py
@@ -47,12 +47,12 @@ def duration_between_ns(start: Timestamp, end: Timestamp) -> Optional[int]:
     """Return a non-negative duration in nanoseconds between two set timestamps."""
     if not _timestamp_is_set(start) or not _timestamp_is_set(end):
         return None
-    return max(
-        0,
+    duration = (
         (end.seconds - start.seconds) * _NANOSECONDS_PER_SECOND
         + end.nanos
-        - start.nanos,
+        - start.nanos
     )
+    return max(0, int(duration))
 
 
 def _timestamp_is_set(timestamp: Timestamp) -> bool:

--- a/cadence/metrics/metrics.py
+++ b/cadence/metrics/metrics.py
@@ -47,7 +47,7 @@ class MetricsEmitter(Protocol):
 
 
 def duration_between_ns(start: Timestamp, end: Timestamp) -> Optional[timedelta]:
-    """Return a non-negative duration between two set protobuf timestamps."""
+    """Return a non-negative duration in nanoseconds (consistent with existing SDK) between two set protobuf timestamps."""
     if not _timestamp_is_set(start) or not _timestamp_is_set(end):
         return None
     return cast(

--- a/cadence/metrics/metrics.py
+++ b/cadence/metrics/metrics.py
@@ -1,11 +1,8 @@
 """Core metrics collection interface and registry for Cadence client."""
 
 import logging
-import time
-from datetime import timedelta, timezone
 from enum import Enum
-from types import TracebackType
-from typing import Callable, Dict, Optional, Protocol, cast
+from typing import Dict, Optional, Protocol
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
@@ -46,81 +43,20 @@ class MetricsEmitter(Protocol):
         ...
 
 
-def duration_between_ns(start: Timestamp, end: Timestamp) -> Optional[timedelta]:
-    """Return a non-negative duration in nanoseconds (consistent with existing SDK) between two set protobuf timestamps."""
+def duration_between_ns(start: Timestamp, end: Timestamp) -> Optional[int]:
+    """Return a non-negative duration in nanoseconds between two set timestamps."""
     if not _timestamp_is_set(start) or not _timestamp_is_set(end):
         return None
-    return cast(
-        timedelta,
-        max(
-            timedelta(0),
-            end.ToDatetime(tzinfo=timezone.utc) - start.ToDatetime(tzinfo=timezone.utc),
-        ),
+    return max(
+        0,
+        (end.seconds - start.seconds) * _NANOSECONDS_PER_SECOND
+        + end.nanos
+        - start.nanos,
     )
-
-
-def record_duration(
-    emitter: MetricsEmitter,
-    key: str,
-    value: timedelta,
-    tags: Optional[Dict[str, str]] = None,
-) -> None:
-    """Record a non-negative duration in the nanoseconds expected by SDK metrics."""
-    if value < timedelta(0):
-        raise ValueError("Metric duration must be non-negative")
-    nanoseconds = (
-        value.days * 86_400 + value.seconds
-    ) * _NANOSECONDS_PER_SECOND + value.microseconds * 1_000
-    if tags is None:
-        emitter.histogram(key, nanoseconds)
-    else:
-        emitter.histogram(key, nanoseconds, tags)
 
 
 def _timestamp_is_set(timestamp: Timestamp) -> bool:
     return bool(timestamp.seconds or timestamp.nanos)
-
-
-class MetricsStopwatch:
-    """Monotonic stopwatch that records a duration metric exactly once."""
-
-    def __init__(
-        self,
-        emitter: MetricsEmitter,
-        key: str,
-        tags: Optional[Dict[str, str]] = None,
-        *,
-        clock_ns: Callable[[], int] = time.monotonic_ns,
-    ) -> None:
-        self._emitter = emitter
-        self._key = key
-        self._tags = tags
-        self._clock_ns = clock_ns
-        self._started_ns = clock_ns()
-        self._elapsed_ns: Optional[int] = None
-
-    def stop(self) -> int:
-        """Record and return elapsed nanoseconds; repeated calls are no-ops."""
-        if self._elapsed_ns is not None:
-            return self._elapsed_ns
-        elapsed_ns = max(0, self._clock_ns() - self._started_ns)
-        if self._tags is None:
-            self._emitter.histogram(self._key, elapsed_ns)
-        else:
-            self._emitter.histogram(self._key, elapsed_ns, self._tags)
-        self._elapsed_ns = elapsed_ns
-        return elapsed_ns
-
-    def __enter__(self) -> "MetricsStopwatch":
-        return self
-
-    def __exit__(
-        self,
-        exc_type: Optional[type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
-    ) -> None:
-        self.stop()
 
 
 class _TaggedEmitter:

--- a/cadence/metrics/metrics.py
+++ b/cadence/metrics/metrics.py
@@ -1,10 +1,17 @@
 """Core metrics collection interface and registry for Cadence client."""
 
 import logging
+import time
+from datetime import timedelta, timezone
 from enum import Enum
-from typing import Dict, Optional, Protocol
+from types import TracebackType
+from typing import Callable, Dict, Optional, Protocol, cast
+
+from google.protobuf.timestamp_pb2 import Timestamp
 
 logger = logging.getLogger(__name__)
+
+_NANOSECONDS_PER_SECOND = 1_000_000_000
 
 
 class MetricType(Enum):
@@ -37,6 +44,83 @@ class MetricsEmitter(Protocol):
     ) -> None:
         """Send a histogram metric."""
         ...
+
+
+def duration_between_ns(start: Timestamp, end: Timestamp) -> Optional[timedelta]:
+    """Return a non-negative duration between two set protobuf timestamps."""
+    if not _timestamp_is_set(start) or not _timestamp_is_set(end):
+        return None
+    return cast(
+        timedelta,
+        max(
+            timedelta(0),
+            end.ToDatetime(tzinfo=timezone.utc) - start.ToDatetime(tzinfo=timezone.utc),
+        ),
+    )
+
+
+def record_duration(
+    emitter: MetricsEmitter,
+    key: str,
+    value: timedelta,
+    tags: Optional[Dict[str, str]] = None,
+) -> None:
+    """Record a non-negative duration in the nanoseconds expected by SDK metrics."""
+    if value < timedelta(0):
+        raise ValueError("Metric duration must be non-negative")
+    nanoseconds = (
+        value.days * 86_400 + value.seconds
+    ) * _NANOSECONDS_PER_SECOND + value.microseconds * 1_000
+    if tags is None:
+        emitter.histogram(key, nanoseconds)
+    else:
+        emitter.histogram(key, nanoseconds, tags)
+
+
+def _timestamp_is_set(timestamp: Timestamp) -> bool:
+    return bool(timestamp.seconds or timestamp.nanos)
+
+
+class MetricsStopwatch:
+    """Monotonic stopwatch that records a duration metric exactly once."""
+
+    def __init__(
+        self,
+        emitter: MetricsEmitter,
+        key: str,
+        tags: Optional[Dict[str, str]] = None,
+        *,
+        clock_ns: Callable[[], int] = time.monotonic_ns,
+    ) -> None:
+        self._emitter = emitter
+        self._key = key
+        self._tags = tags
+        self._clock_ns = clock_ns
+        self._started_ns = clock_ns()
+        self._elapsed_ns: Optional[int] = None
+
+    def stop(self) -> int:
+        """Record and return elapsed nanoseconds; repeated calls are no-ops."""
+        if self._elapsed_ns is not None:
+            return self._elapsed_ns
+        elapsed_ns = max(0, self._clock_ns() - self._started_ns)
+        if self._tags is None:
+            self._emitter.histogram(self._key, elapsed_ns)
+        else:
+            self._emitter.histogram(self._key, elapsed_ns, self._tags)
+        self._elapsed_ns = elapsed_ns
+        return elapsed_ns
+
+    def __enter__(self) -> "MetricsStopwatch":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.stop()
 
 
 class _TaggedEmitter:

--- a/cadence/worker/_activity.py
+++ b/cadence/worker/_activity.py
@@ -81,7 +81,7 @@ class ActivityWorker:
             raise
 
     async def _poll(self) -> Optional[PollForActivityTaskResponse]:
-        async with self._poll_metrics.track() as start:
+        async with self._poll_metrics.track():
             task: PollForActivityTaskResponse = (
                 await self._client.worker_stub.PollForActivityTask(
                     PollForActivityTaskRequest(
@@ -95,7 +95,7 @@ class ActivityWorker:
                     timeout=_LONG_POLL_TIMEOUT,
                 )
             )
-            self._poll_metrics.record_result(start, task)
+            self._poll_metrics.record_result(task)
             return task if task.task_token else None
 
     async def _execute(self, task: PollForActivityTaskResponse) -> None:

--- a/cadence/worker/_decision.py
+++ b/cadence/worker/_decision.py
@@ -82,7 +82,7 @@ class DecisionWorker:
             raise
 
     async def _poll(self) -> Optional[PollForDecisionTaskResponse]:
-        async with self._poll_metrics.track() as start:
+        async with self._poll_metrics.track():
             task: PollForDecisionTaskResponse = (
                 await self._client.worker_stub.PollForDecisionTask(
                     PollForDecisionTaskRequest(
@@ -96,7 +96,7 @@ class DecisionWorker:
                     timeout=_LONG_POLL_TIMEOUT,
                 )
             )
-            self._poll_metrics.record_result(start, task)
+            self._poll_metrics.record_result(task)
             return task if (task and task.task_token) else None
 
     async def _execute(self, task: PollForDecisionTaskResponse) -> None:

--- a/cadence/worker/_poll_metrics.py
+++ b/cadence/worker/_poll_metrics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Protocol
@@ -12,8 +13,6 @@ from cadence.error import CadenceRpcError
 from cadence.metrics import (
     duration_between_ns,
     MetricsEmitter,
-    MetricsStopwatch,
-    record_duration,
 )
 
 
@@ -38,7 +37,7 @@ class PollMetrics:
     async def track(self) -> AsyncIterator[None]:
         """Emit poll counter; guarantee exactly one outcome counter on error."""
         self.emitter.counter(self.poll)
-        stopwatch = MetricsStopwatch(self.emitter, self.latency)
+        start = time.monotonic_ns()
         try:
             yield
         except CadenceRpcError as e:
@@ -49,7 +48,7 @@ class PollMetrics:
             self.emitter.counter(self.failed)
             raise
         finally:
-            stopwatch.stop()
+            self.emitter.histogram(self.latency, time.monotonic_ns() - start)
 
     def record_result(self, task: PollTask) -> None:
         """Record succeed vs idle and optional schedule-to-start latency."""
@@ -57,6 +56,6 @@ class PollMetrics:
             self.emitter.counter(self.no_task)
             return
         self.emitter.counter(self.succeed)
-        latency = duration_between_ns(task.scheduled_time, task.started_time)
-        if latency is not None:
-            record_duration(self.emitter, self.scheduled_to_start, latency)
+        latency_ns = duration_between_ns(task.scheduled_time, task.started_time)
+        if latency_ns is not None:
+            self.emitter.histogram(self.scheduled_to_start, latency_ns)

--- a/cadence/worker/_poll_metrics.py
+++ b/cadence/worker/_poll_metrics.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Protocol
@@ -10,7 +9,12 @@ from google.protobuf import timestamp_pb2
 
 from cadence._internal.rpc.retry import RETRYABLE_CODES
 from cadence.error import CadenceRpcError
-from cadence.metrics import MetricsEmitter
+from cadence.metrics import (
+    duration_between_ns,
+    MetricsEmitter,
+    MetricsStopwatch,
+    record_duration,
+)
 
 
 class PollTask(Protocol):
@@ -31,29 +35,28 @@ class PollMetrics:
     scheduled_to_start: str
 
     @contextlib.asynccontextmanager
-    async def track(self) -> AsyncIterator[float]:
+    async def track(self) -> AsyncIterator[None]:
         """Emit poll counter; guarantee exactly one outcome counter on error."""
         self.emitter.counter(self.poll)
-        start = time.monotonic()
+        stopwatch = MetricsStopwatch(self.emitter, self.latency)
         try:
-            yield start
+            yield
         except CadenceRpcError as e:
-            self.emitter.histogram(self.latency, time.monotonic() - start)
             metric = self.transient_failed if e.code in RETRYABLE_CODES else self.failed
             self.emitter.counter(metric)
             raise
         except Exception:
             self.emitter.counter(self.failed)
             raise
+        finally:
+            stopwatch.stop()
 
-    def record_result(self, start: float, task: PollTask) -> None:
-        """Record latency, then succeed vs idle, and optional schedule-to-start lag."""
-        self.emitter.histogram(self.latency, time.monotonic() - start)
+    def record_result(self, task: PollTask) -> None:
+        """Record succeed vs idle and optional schedule-to-start lag."""
         if not (task and task.task_token):
             self.emitter.counter(self.no_task)
             return
         self.emitter.counter(self.succeed)
-        s, e = task.scheduled_time, task.started_time
-        if (s.seconds or s.nanos) and (e.seconds or e.nanos):
-            lag = (e.ToDatetime() - s.ToDatetime()).total_seconds()
-            self.emitter.histogram(self.scheduled_to_start, max(0.0, lag))
+        lag = duration_between_ns(task.scheduled_time, task.started_time)
+        if lag is not None:
+            record_duration(self.emitter, self.scheduled_to_start, lag)

--- a/cadence/worker/_poll_metrics.py
+++ b/cadence/worker/_poll_metrics.py
@@ -52,11 +52,11 @@ class PollMetrics:
             stopwatch.stop()
 
     def record_result(self, task: PollTask) -> None:
-        """Record succeed vs idle and optional schedule-to-start lag."""
+        """Record succeed vs idle and optional schedule-to-start latency."""
         if not (task and task.task_token):
             self.emitter.counter(self.no_task)
             return
         self.emitter.counter(self.succeed)
-        lag = duration_between_ns(task.scheduled_time, task.started_time)
-        if lag is not None:
-            record_duration(self.emitter, self.scheduled_to_start, lag)
+        latency = duration_between_ns(task.scheduled_time, task.started_time)
+        if latency is not None:
+            record_duration(self.emitter, self.scheduled_to_start, latency)

--- a/tests/cadence/metrics/test_metrics.py
+++ b/tests/cadence/metrics/test_metrics.py
@@ -1,13 +1,23 @@
 """Tests for metrics collection functionality."""
 
+from datetime import timedelta
 from unittest.mock import Mock
 
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
 
 from cadence.metrics import (
+    duration_between_ns,
     MetricsEmitter,
+    MetricsStopwatch,
     MetricType,
     NoOpMetricsEmitter,
+    record_duration,
 )
+
+
+def _timestamp(seconds: int = 0, nanos: int = 0) -> Timestamp:
+    return Timestamp(seconds=seconds, nanos=nanos)
 
 
 class TestMetricsEmitter:
@@ -51,3 +61,73 @@ class TestMetricType:
         assert MetricType.COUNTER.value == "counter"
         assert MetricType.GAUGE.value == "gauge"
         assert MetricType.HISTOGRAM.value == "histogram"
+
+
+class TestDurationMetrics:
+    def test_duration_between_ns_set_timestamps(self):
+        assert duration_between_ns(
+            _timestamp(seconds=10, nanos=100_000_000),
+            _timestamp(seconds=12, nanos=350_000_000),
+        ) == timedelta(seconds=2, microseconds=250_000)
+
+    def test_duration_between_ns_requires_both_timestamps(self):
+        assert duration_between_ns(_timestamp(), _timestamp(seconds=1)) is None
+        assert duration_between_ns(_timestamp(seconds=1), _timestamp()) is None
+
+    def test_duration_between_ns_clamps_clock_skew(self):
+        assert duration_between_ns(
+            _timestamp(seconds=2),
+            _timestamp(seconds=1),
+        ) == timedelta(0)
+
+    def test_record_duration_converts_to_nanoseconds(self):
+        emitter = Mock(spec=MetricsEmitter)
+
+        record_duration(
+            emitter,
+            "latency_ns",
+            timedelta(seconds=2, microseconds=345),
+            {"operation": "test"},
+        )
+
+        emitter.histogram.assert_called_once_with(
+            "latency_ns",
+            2_000_345_000,
+            {"operation": "test"},
+        )
+
+    def test_record_duration_rejects_negative_values(self):
+        emitter = Mock(spec=MetricsEmitter)
+
+        with pytest.raises(ValueError, match="non-negative"):
+            record_duration(emitter, "latency_ns", timedelta(microseconds=-1))
+
+        emitter.histogram.assert_not_called()
+
+    def test_stopwatch_records_once_using_monotonic_nanoseconds(self):
+        emitter = Mock(spec=MetricsEmitter)
+        clock = Mock(side_effect=[10, 42])
+        stopwatch = MetricsStopwatch(emitter, "latency_ns", clock_ns=clock)
+
+        assert stopwatch.stop() == 32
+        assert stopwatch.stop() == 32
+
+        emitter.histogram.assert_called_once_with("latency_ns", 32)
+
+    def test_stopwatch_context_manager_records_with_tags(self):
+        emitter = Mock(spec=MetricsEmitter)
+        clock = Mock(side_effect=[100, 150])
+
+        with MetricsStopwatch(
+            emitter,
+            "latency_ns",
+            {"operation": "test"},
+            clock_ns=clock,
+        ):
+            pass
+
+        emitter.histogram.assert_called_once_with(
+            "latency_ns",
+            50,
+            {"operation": "test"},
+        )

--- a/tests/cadence/metrics/test_metrics.py
+++ b/tests/cadence/metrics/test_metrics.py
@@ -1,18 +1,14 @@
 """Tests for metrics collection functionality."""
 
-from datetime import timedelta
 from unittest.mock import Mock
 
-import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from cadence.metrics import (
     duration_between_ns,
     MetricsEmitter,
-    MetricsStopwatch,
     MetricType,
     NoOpMetricsEmitter,
-    record_duration,
 )
 
 
@@ -65,69 +61,23 @@ class TestMetricType:
 
 class TestDurationMetrics:
     def test_duration_between_ns_set_timestamps(self):
-        assert duration_between_ns(
-            _timestamp(seconds=10, nanos=100_000_000),
-            _timestamp(seconds=12, nanos=350_000_000),
-        ) == timedelta(seconds=2, microseconds=250_000)
+        assert (
+            duration_between_ns(
+                _timestamp(seconds=10, nanos=100_000_000),
+                _timestamp(seconds=12, nanos=350_000_000),
+            )
+            == 2_250_000_000
+        )
 
     def test_duration_between_ns_requires_both_timestamps(self):
         assert duration_between_ns(_timestamp(), _timestamp(seconds=1)) is None
         assert duration_between_ns(_timestamp(seconds=1), _timestamp()) is None
 
     def test_duration_between_ns_clamps_clock_skew(self):
-        assert duration_between_ns(
-            _timestamp(seconds=2),
-            _timestamp(seconds=1),
-        ) == timedelta(0)
-
-    def test_record_duration_converts_to_nanoseconds(self):
-        emitter = Mock(spec=MetricsEmitter)
-
-        record_duration(
-            emitter,
-            "latency_ns",
-            timedelta(seconds=2, microseconds=345),
-            {"operation": "test"},
-        )
-
-        emitter.histogram.assert_called_once_with(
-            "latency_ns",
-            2_000_345_000,
-            {"operation": "test"},
-        )
-
-    def test_record_duration_rejects_negative_values(self):
-        emitter = Mock(spec=MetricsEmitter)
-
-        with pytest.raises(ValueError, match="non-negative"):
-            record_duration(emitter, "latency_ns", timedelta(microseconds=-1))
-
-        emitter.histogram.assert_not_called()
-
-    def test_stopwatch_records_once_using_monotonic_nanoseconds(self):
-        emitter = Mock(spec=MetricsEmitter)
-        clock = Mock(side_effect=[10, 42])
-        stopwatch = MetricsStopwatch(emitter, "latency_ns", clock_ns=clock)
-
-        assert stopwatch.stop() == 32
-        assert stopwatch.stop() == 32
-
-        emitter.histogram.assert_called_once_with("latency_ns", 32)
-
-    def test_stopwatch_context_manager_records_with_tags(self):
-        emitter = Mock(spec=MetricsEmitter)
-        clock = Mock(side_effect=[100, 150])
-
-        with MetricsStopwatch(
-            emitter,
-            "latency_ns",
-            {"operation": "test"},
-            clock_ns=clock,
-        ):
-            pass
-
-        emitter.histogram.assert_called_once_with(
-            "latency_ns",
-            50,
-            {"operation": "test"},
+        assert (
+            duration_between_ns(
+                _timestamp(seconds=2),
+                _timestamp(seconds=1),
+            )
+            == 0
         )

--- a/tests/cadence/worker/test_poll_metrics.py
+++ b/tests/cadence/worker/test_poll_metrics.py
@@ -200,7 +200,7 @@ class TestDecisionWorkerPollMetrics:
         histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
         assert DECISION_SCHEDULED_TO_START_LATENCY in histogram_calls
         latency_call = histogram_calls[DECISION_SCHEDULED_TO_START_LATENCY]
-        assert abs(latency_call.args[1] - 2.0) < 0.01
+        assert latency_call.args[1] == 2_000_000_000
 
     @pytest.mark.asyncio
     async def test_no_scheduled_to_start_when_timestamps_zero(self):
@@ -268,6 +268,23 @@ class TestDecisionWorkerPollMetrics:
 
         emitter.counter.assert_any_call(
             DECISION_POLL_FAILED_COUNTER, 1, tags=EXPECTED_TAGS
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_latency_on_unexpected_error(self):
+        emitter = _mock_emitter()
+        client = _mock_client()
+        client.worker_stub.PollForDecisionTask = AsyncMock(
+            side_effect=RuntimeError("unexpected")
+        )
+        worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
+
+        with pytest.raises(RuntimeError, match="unexpected"):
+            await worker._poll()
+
+        assert any(
+            call.args[0] == DECISION_POLL_LATENCY
+            for call in emitter.histogram.call_args_list
         )
 
 
@@ -393,8 +410,8 @@ class TestActivityWorkerPollMetrics:
         histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
         assert ACTIVITY_SCHEDULED_TO_START_LATENCY in histogram_calls
         assert (
-            abs(histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] - 3.0)
-            < 0.01
+            histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1]
+            == 3_000_000_000
         )
 
     @pytest.mark.asyncio
@@ -412,8 +429,7 @@ class TestActivityWorkerPollMetrics:
 
         histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
         assert (
-            abs(histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] - 0.2)
-            < 0.01
+            histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] == 200_000_000
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adds shared duration timing utilities and updates worker poll metrics to use them, with nanosecond histograms and consistent latency recording on all poll outcomes.

<!-- Tell your future self why have you made these changes -->
**Why?**

Unify duration measurement across the SDK and fix inconsistent poll latency reporting.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit tests.