### PR TITLE
refactor(metrics): use typed duration instead of primitive

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -41,6 +41,11 @@ pip install -e ".[dev]"
 - Use `uv tool run ruff check --fix && uv run mypy cadence/` to run both together
 - **Standard workflow**: Make changes → Run linter → Run type checker → Commit
 
+## Time Types
+- Use `datetime` for internal points in time and `timedelta` for internal durations.
+- Use protobuf `Timestamp` and `Duration` only at gRPC/protobuf message boundaries.
+- Do not use raw `float` or `int` values for time units unless an external API explicitly requires them.
+
 ## Development Workflow
 1. Make code changes
 2. Run `uv tool run ruff check --fix` (fixes formatting and linting issues)

--- a/cadence/_internal/activity/_activity_executor.py
+++ b/cadence/_internal/activity/_activity_executor.py
@@ -1,13 +1,12 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 from logging import getLogger
 import time
 from traceback import format_exception
 from typing import Any, Callable, Optional, Union, cast
 from google.protobuf.duration import to_timedelta
 from google.protobuf.timestamp import to_datetime
-from google.protobuf.timestamp_pb2 import Timestamp
-
 from cadence._internal.activity._context import _Context, _SyncContext
 from cadence._internal.activity._definition import BaseDefinition, ExecutionStrategy
 from cadence._internal.activity._heartbeat import _HeartbeatSender
@@ -20,7 +19,12 @@ from cadence.api.v1.service_worker_pb2 import (
     RespondActivityTaskCompletedRequest,
 )
 from cadence.client import Client
-from cadence.metrics import duration_between_ns, MetricsEmitter, NoOpMetricsEmitter
+from cadence.metrics import (
+    duration_between,
+    duration_from_nanoseconds,
+    MetricsEmitter,
+    NoOpMetricsEmitter,
+)
 from cadence.metrics.constants import (
     ACTIVITY_END_TO_END_LATENCY,
     ACTIVITY_EXECUTION_FAILED_COUNTER,
@@ -99,23 +103,21 @@ class ActivityExecutor:
             error = e
         finally:
             emitter.histogram(
-                ACTIVITY_EXECUTION_LATENCY, time.monotonic_ns() - exec_start_ns
+                ACTIVITY_EXECUTION_LATENCY,
+                duration_from_nanoseconds(time.monotonic_ns() - exec_start_ns),
             )
 
-        now = Timestamp()
-        now.GetCurrentTime()
-        e2e_latency_ns = duration_between_ns(task.scheduled_time, now)
-        if e2e_latency_ns is None:
+        e2e_latency = duration_between(task.scheduled_time, datetime.now(timezone.utc))
+        if e2e_latency is None:
             _logger.warning(
                 "Activity task is missing scheduled_time; skipping end-to-end latency"
             )
-            e2e_latency_ns = -1
         if error is not None:
             emitter.counter(ACTIVITY_EXECUTION_FAILED_COUNTER)
             _logger.error("Activity failed", exc_info=error)
-            await self._report_failure(task, error, emitter, e2e_latency_ns)
+            await self._report_failure(task, error, emitter, e2e_latency)
         else:
-            await self._report_success(task, result, emitter, e2e_latency_ns)
+            await self._report_success(task, result, emitter, e2e_latency)
 
     def _create_context(
         self, task: PollForActivityTaskResponse
@@ -150,7 +152,7 @@ class ActivityExecutor:
         task: PollForActivityTaskResponse,
         error: Exception,
         emitter: MetricsEmitter,
-        e2e_latency_ns: int,
+        e2e_latency: timedelta | None,
     ):
         resp_start_ns = time.monotonic_ns()
         try:
@@ -162,14 +164,15 @@ class ActivityExecutor:
                 )
             )
             emitter.counter(ACTIVITY_TASK_FAILED_COUNTER)
-            if e2e_latency_ns >= 0:
-                emitter.histogram(ACTIVITY_END_TO_END_LATENCY, e2e_latency_ns)
+            if e2e_latency is not None and e2e_latency >= timedelta(0):
+                emitter.histogram(ACTIVITY_END_TO_END_LATENCY, e2e_latency)
         except Exception:
             emitter.counter(ACTIVITY_RESPONSE_FAILED_COUNTER)
             _logger.exception("Exception reporting activity failure")
         finally:
             emitter.histogram(
-                ACTIVITY_RESPONSE_LATENCY, time.monotonic_ns() - resp_start_ns
+                ACTIVITY_RESPONSE_LATENCY,
+                duration_from_nanoseconds(time.monotonic_ns() - resp_start_ns),
             )
 
     async def _report_cancelled(
@@ -194,7 +197,8 @@ class ActivityExecutor:
             _logger.exception("Exception reporting activity cancelled")
         finally:
             emitter.histogram(
-                ACTIVITY_RESPONSE_LATENCY, time.monotonic_ns() - resp_start_ns
+                ACTIVITY_RESPONSE_LATENCY,
+                duration_from_nanoseconds(time.monotonic_ns() - resp_start_ns),
             )
 
     async def _report_success(
@@ -202,7 +206,7 @@ class ActivityExecutor:
         task: PollForActivityTaskResponse,
         result: Any,
         emitter: MetricsEmitter,
-        e2e_latency_ns: int,
+        e2e_latency: timedelta | None,
     ):
         as_payload = self._data_converter.to_data([result])
         resp_start_ns = time.monotonic_ns()
@@ -215,14 +219,15 @@ class ActivityExecutor:
                 )
             )
             emitter.counter(ACTIVITY_TASK_COMPLETED_COUNTER)
-            if e2e_latency_ns >= 0:
-                emitter.histogram(ACTIVITY_END_TO_END_LATENCY, e2e_latency_ns)
+            if e2e_latency is not None and e2e_latency >= timedelta(0):
+                emitter.histogram(ACTIVITY_END_TO_END_LATENCY, e2e_latency)
         except Exception:
             emitter.counter(ACTIVITY_RESPONSE_FAILED_COUNTER)
             _logger.exception("Exception reporting activity complete")
         finally:
             emitter.histogram(
-                ACTIVITY_RESPONSE_LATENCY, time.monotonic_ns() - resp_start_ns
+                ACTIVITY_RESPONSE_LATENCY,
+                duration_from_nanoseconds(time.monotonic_ns() - resp_start_ns),
             )
 
     def _create_info(self, task: PollForActivityTaskResponse) -> ActivityInfo:

--- a/cadence/_internal/activity/_context.py
+++ b/cadence/_internal/activity/_context.py
@@ -100,7 +100,7 @@ class _Context(ActivityContext):
     def is_cancelled(self) -> bool:
         return self._cancel_event.is_set()
 
-    def wait_for_cancelled(self, timeout: timedelta | float | None = None) -> bool:
+    def wait_for_cancelled(self, timeout: timedelta | None = None) -> bool:
         raise RuntimeError(
             "wait_for_cancelled is only supported in sync activities; "
             "handle asyncio.CancelledError in async activities instead"
@@ -156,11 +156,9 @@ class _SyncContext(_Context):
         except Exception:
             pass
 
-    def wait_for_cancelled(self, timeout: timedelta | float | None = None) -> bool:
+    def wait_for_cancelled(self, timeout: timedelta | None = None) -> bool:
         if timeout is None:
             sec: float | None = None
-        elif isinstance(timeout, timedelta):
-            sec = timeout.total_seconds()
         else:
-            sec = float(timeout)
+            sec = timeout.total_seconds()
         return self._sync_cancel_event.wait(sec)

--- a/cadence/_internal/rpc/retry.py
+++ b/cadence/_internal/rpc/retry.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Callable, Any, cast
 
 from grpc import StatusCode
@@ -18,15 +19,18 @@ RETRYABLE_CODES = {
 # No expiration interval, use the GRPC timeout value instead
 @dataclass
 class ExponentialRetryPolicy:
-    initial_interval: float
+    initial_interval: timedelta
     backoff_coefficient: float
-    max_interval: float
-    max_attempts: float
+    max_interval: timedelta
+    max_attempts: int
 
     def next_delay(
-        self, attempts: int, elapsed: float, expiration: float
-    ) -> float | None:
-        if elapsed >= expiration:
+        self,
+        attempts: int,
+        elapsed: timedelta,
+        expiration: timedelta | None,
+    ) -> timedelta | None:
+        if expiration is not None and elapsed >= expiration:
             return None
         if self.max_attempts != 0 and attempts >= self.max_attempts:
             return None
@@ -35,14 +39,17 @@ class ExponentialRetryPolicy:
             self.initial_interval * pow(self.backoff_coefficient, attempts - 1),
             self.max_interval,
         )
-        if (elapsed + backoff) >= expiration:
+        if expiration is not None and (elapsed + backoff) >= expiration:
             return None
 
         return backoff
 
 
 DEFAULT_RETRY_POLICY = ExponentialRetryPolicy(
-    initial_interval=0.02, backoff_coefficient=1.2, max_interval=6, max_attempts=0
+    initial_interval=timedelta(milliseconds=20),
+    backoff_coefficient=1.2,
+    max_interval=timedelta(seconds=6),
+    max_attempts=0,
 )
 GET_WORKFLOW_HISTORY = b"/uber.cadence.api.v1.WorkflowAPI/GetWorkflowExecutionHistory"
 
@@ -60,19 +67,23 @@ class RetryInterceptor(UnaryUnaryClientInterceptor):
     ) -> Any:
         loop = asyncio.get_running_loop()
         expiration_interval = (
-            client_call_details.timeout
+            timedelta(seconds=client_call_details.timeout)
             if client_call_details.timeout is not None
-            else float("inf")
+            else None
         )
         start_time = loop.time()
-        deadline = start_time + expiration_interval
 
         attempts = 0
         while True:
-            remaining = deadline - loop.time()
+            elapsed = timedelta(seconds=loop.time() - start_time)
+            remaining = (
+                expiration_interval - elapsed
+                if expiration_interval is not None
+                else None
+            )
             call_details = ClientCallDetails(
                 method=client_call_details.method,
-                timeout=remaining,
+                timeout=remaining.total_seconds() if remaining is not None else None,
                 metadata=client_call_details.metadata,
                 credentials=client_call_details.credentials,
                 wait_for_ready=client_call_details.wait_for_ready,
@@ -88,14 +99,14 @@ class RetryInterceptor(UnaryUnaryClientInterceptor):
                 err = e
 
             attempts += 1
-            elapsed = loop.time() - start_time
+            elapsed = timedelta(seconds=loop.time() - start_time)
             backoff = self._retry_policy.next_delay(
                 attempts, elapsed, expiration_interval
             )
             if not is_retryable(err, client_call_details) or backoff is None:
                 break
 
-            await asyncio.sleep(backoff)
+            await asyncio.sleep(backoff.total_seconds())
 
         # On policy expiration, return the most recent UnaryUnaryCall. It has the error we want
         return rpc_call

--- a/cadence/_internal/rpc/retry.py
+++ b/cadence/_internal/rpc/retry.py
@@ -83,7 +83,9 @@ class RetryInterceptor(UnaryUnaryClientInterceptor):
             )
             call_details = ClientCallDetails(
                 method=client_call_details.method,
-                timeout=remaining.total_seconds() if remaining is not None else None,
+                timeout=max(remaining, timedelta(0)).total_seconds()
+                if remaining is not None
+                else None,
                 metadata=client_call_details.metadata,
                 credentials=client_call_details.credentials,
                 wait_for_ready=client_call_details.wait_for_ready,

--- a/cadence/_internal/rpc/yarpc.py
+++ b/cadence/_internal/rpc/yarpc.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import Any, Callable
 
 from grpc.aio import Metadata
@@ -40,7 +41,8 @@ class YarpcMetadataInterceptor(UnaryUnaryClientInterceptor):
 
         return ClientCallDetails(
             method=client_call_details.method,
-            timeout=client_call_details.timeout or 60.0,
+            timeout=client_call_details.timeout
+            or timedelta(seconds=60).total_seconds(),
             metadata=metadata,
             credentials=client_call_details.credentials,
             wait_for_ready=client_call_details.wait_for_ready,

--- a/cadence/_internal/workflow/context.py
+++ b/cadence/_internal/workflow/context.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from asyncio import get_running_loop
-from datetime import timedelta
+from datetime import datetime, timedelta
 from math import ceil
 from typing import Iterator, Optional, Any, Unpack, Type, cast, Callable
 
@@ -45,7 +45,7 @@ class Context(WorkflowContext):
     ):
         self._info = info
         self._replay_mode = True
-        self._replay_current_time_milliseconds: Optional[int] = None
+        self._replay_current_time: Optional[datetime] = None
         self._decision_manager = decision_manager
         self._cancellation_info: WorkflowCancellationInfo | None = None
 
@@ -100,13 +100,21 @@ class Context(WorkflowContext):
             domain=self.info().workflow_domain,
             task_list=TaskList(kind=TaskListKind.TASK_LIST_KIND_NORMAL, name=task_list),
             input=activity_input,
-            schedule_to_close_timeout=_round_to_nearest_second(schedule_to_close),
-            schedule_to_start_timeout=_round_to_nearest_second(schedule_to_start),
-            start_to_close_timeout=_round_to_nearest_second(start_to_close),
-            heartbeat_timeout=_round_to_nearest_second(heartbeat),
             retry_policy=retry_policy_to_proto(opts.get("retry_policy")),
             header=None,
             request_local_dispatch=False,
+        )
+        schedule_attributes.schedule_to_close_timeout.FromTimedelta(
+            _round_to_nearest_second(schedule_to_close)
+        )
+        schedule_attributes.schedule_to_start_timeout.FromTimedelta(
+            _round_to_nearest_second(schedule_to_start)
+        )
+        schedule_attributes.start_to_close_timeout.FromTimedelta(
+            _round_to_nearest_second(start_to_close)
+        )
+        schedule_attributes.heartbeat_timeout.FromTimedelta(
+            _round_to_nearest_second(heartbeat)
         )
 
         future = self._decision_manager.schedule_activity(schedule_attributes)
@@ -196,13 +204,15 @@ class Context(WorkflowContext):
             workflow_type=WorkflowType(name=workflow_type),
             task_list=TaskList(kind=TaskListKind.TASK_LIST_KIND_NORMAL, name=task_list),
             input=child_input,
-            execution_start_to_close_timeout=_round_to_nearest_second(
-                execution_timeout
-            ),
-            task_start_to_close_timeout=_round_to_nearest_second(task_timeout),
             parent_close_policy=parent_close_policy,
             workflow_id_reuse_policy=workflow_id_reuse_policy,
             retry_policy=retry_policy_to_proto(kwargs.get("retry_policy")),
+        )
+        schedule_attributes.execution_start_to_close_timeout.FromTimedelta(
+            _round_to_nearest_second(execution_timeout)
+        )
+        schedule_attributes.task_start_to_close_timeout.FromTimedelta(
+            _round_to_nearest_second(task_timeout)
         )
 
         cron_schedule = kwargs.get("cron_schedule")
@@ -244,11 +254,9 @@ class Context(WorkflowContext):
     async def start_timer(self, duration: timedelta):
         if duration.total_seconds() <= 0:  # shortcut
             return
-        future = self._decision_manager.start_timer(
-            StartTimerDecisionAttributes(
-                start_to_fire_timeout=duration,
-            )
-        )
+        attributes = StartTimerDecisionAttributes()
+        attributes.start_to_fire_timeout.FromTimedelta(duration)
+        future = self._decision_manager.start_timer(attributes)
         await future
 
     def set_replay_mode(self, replay: bool) -> None:
@@ -259,13 +267,13 @@ class Context(WorkflowContext):
         """Check if the workflow is currently in replay mode."""
         return self._replay_mode
 
-    def set_replay_current_time_milliseconds(self, time_millis: int) -> None:
-        """Set the current replay time in milliseconds."""
-        self._replay_current_time_milliseconds = time_millis
+    def set_replay_current_time(self, current_time: datetime) -> None:
+        """Set the current replay timestamp."""
+        self._replay_current_time = current_time
 
-    def get_replay_current_time_milliseconds(self) -> Optional[int]:
-        """Get the current replay time in milliseconds."""
-        return self._replay_current_time_milliseconds
+    def get_replay_current_time(self) -> Optional[datetime]:
+        """Get the current replay timestamp."""
+        return self._replay_current_time
 
     async def wait_condition(self, predicate: Callable[[], bool]) -> None:
         loop = cast(DeterministicEventLoop, get_running_loop())

--- a/cadence/_internal/workflow/context.py
+++ b/cadence/_internal/workflow/context.py
@@ -103,18 +103,10 @@ class Context(WorkflowContext):
             retry_policy=retry_policy_to_proto(opts.get("retry_policy")),
             header=None,
             request_local_dispatch=False,
-        )
-        schedule_attributes.schedule_to_close_timeout.FromTimedelta(
-            _round_to_nearest_second(schedule_to_close)
-        )
-        schedule_attributes.schedule_to_start_timeout.FromTimedelta(
-            _round_to_nearest_second(schedule_to_start)
-        )
-        schedule_attributes.start_to_close_timeout.FromTimedelta(
-            _round_to_nearest_second(start_to_close)
-        )
-        schedule_attributes.heartbeat_timeout.FromTimedelta(
-            _round_to_nearest_second(heartbeat)
+            schedule_to_close_timeout=_round_to_nearest_second(schedule_to_close),
+            schedule_to_start_timeout=_round_to_nearest_second(schedule_to_start),
+            start_to_close_timeout=_round_to_nearest_second(start_to_close),
+            heartbeat_timeout=_round_to_nearest_second(heartbeat),
         )
 
         future = self._decision_manager.schedule_activity(schedule_attributes)
@@ -207,12 +199,10 @@ class Context(WorkflowContext):
             parent_close_policy=parent_close_policy,
             workflow_id_reuse_policy=workflow_id_reuse_policy,
             retry_policy=retry_policy_to_proto(kwargs.get("retry_policy")),
-        )
-        schedule_attributes.execution_start_to_close_timeout.FromTimedelta(
-            _round_to_nearest_second(execution_timeout)
-        )
-        schedule_attributes.task_start_to_close_timeout.FromTimedelta(
-            _round_to_nearest_second(task_timeout)
+            execution_start_to_close_timeout=_round_to_nearest_second(
+                execution_timeout
+            ),
+            task_start_to_close_timeout=_round_to_nearest_second(task_timeout),
         )
 
         cron_schedule = kwargs.get("cron_schedule")

--- a/cadence/_internal/workflow/decision_events_iterator.py
+++ b/cadence/_internal/workflow/decision_events_iterator.py
@@ -7,6 +7,7 @@ particularly focusing on decision-related events for replay and execution.
 """
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Iterator, List, Optional
 
 from cadence._internal.workflow.history_event_iterator import HistoryEventsIterator
@@ -23,7 +24,7 @@ class DecisionEvents:
     output: List[HistoryEvent]
     markers: List[HistoryEvent]
     replay: bool
-    replay_current_time_milliseconds: int
+    replay_current_time: datetime
     next_decision_event_id: int
 
     def get_output_event_by_id(self, event_id: int) -> Optional[HistoryEvent]:
@@ -47,7 +48,6 @@ class DecisionEventsIterator(Iterator[DecisionEvents]):
     ):
         self._events: HistoryEventsIterator = HistoryEventsIterator(events)
         self._next_decision_event_id: Optional[int] = None
-        self._replay_current_time_milliseconds: Optional[int] = None
 
     def __iter__(self):
         return self
@@ -104,7 +104,7 @@ class DecisionEventsIterator(Iterator[DecisionEvents]):
                 break
             decision_output_events.append(next(self._events))
 
-        replay_current_time_milliseconds = decision_event.event_time.ToMilliseconds()
+        replay_current_time = decision_event.event_time.ToDatetime(tzinfo=timezone.utc)
 
         replay: bool
         next_decision_event_id: int
@@ -126,7 +126,7 @@ class DecisionEventsIterator(Iterator[DecisionEvents]):
             output=decision_output_events,
             markers=markers,
             replay=replay,
-            replay_current_time_milliseconds=replay_current_time_milliseconds,
+            replay_current_time=replay_current_time,
             next_decision_event_id=next_decision_event_id,
         )
 

--- a/cadence/_internal/workflow/history_event_iterator.py
+++ b/cadence/_internal/workflow/history_event_iterator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Iterator, List, Optional
+from typing import Iterator, List, Optional
 
 from cadence.api.v1.history_pb2 import HistoryEvent
 from cadence.api.v1.service_worker_pb2 import PollForDecisionTaskResponse
@@ -10,19 +10,17 @@ from cadence.api.v1.service_workflow_pb2 import (
     GetWorkflowExecutionHistoryResponse,
 )
 from cadence.client import Client
+from cadence.metrics import MetricsEmitter, duration_from_nanoseconds
 from cadence.metrics.constants import (
     WORKFLOW_GET_HISTORY_COUNTER,
     WORKFLOW_GET_HISTORY_LATENCY,
 )
 
-if TYPE_CHECKING:
-    from cadence.metrics import MetricsEmitter
-
 
 async def iterate_history_events(
     decision_task: PollForDecisionTaskResponse,
     client: Client,
-    metrics_emitter: Optional[MetricsEmitter] = None,
+    metrics_emitter: MetricsEmitter,
 ):
     PAGE_SIZE = 1000
 
@@ -46,11 +44,11 @@ async def iterate_history_events(
                 )
             )
         )
-        if metrics_emitter is not None:
-            metrics_emitter.counter(WORKFLOW_GET_HISTORY_COUNTER)
-            metrics_emitter.histogram(
-                WORKFLOW_GET_HISTORY_LATENCY, time.monotonic_ns() - fetch_start_ns
-            )
+        metrics_emitter.counter(WORKFLOW_GET_HISTORY_COUNTER)
+        metrics_emitter.histogram(
+            WORKFLOW_GET_HISTORY_LATENCY,
+            duration_from_nanoseconds(time.monotonic_ns() - fetch_start_ns),
+        )
         current_page = response.history.events
         next_page_token = response.next_page_token
 

--- a/cadence/_internal/workflow/workflow_engine.py
+++ b/cadence/_internal/workflow/workflow_engine.py
@@ -167,16 +167,13 @@ class WorkflowEngine:
                     "workflow_id": ctx.info().workflow_id,
                     "markers_count": len(decision_events.markers),
                     "replay_mode": decision_events.replay,
-                    "replay_time": decision_events.replay_current_time_milliseconds,
+                    "replay_time": decision_events.replay_current_time,
                 },
             )
 
             # Update context with replay information
             ctx.set_replay_mode(decision_events.replay)
-            if decision_events.replay_current_time_milliseconds:
-                ctx.set_replay_current_time_milliseconds(
-                    decision_events.replay_current_time_milliseconds
-                )
+            ctx.set_replay_current_time(decision_events.replay_current_time)
             with self._decision_manager.track_nondeterminism(
                 decision_events.replay, decision_events.output
             ):

--- a/cadence/activity.py
+++ b/cadence/activity.py
@@ -130,13 +130,12 @@ def raise_if_cancelled() -> None:
         raise ActivityCancelledError()
 
 
-def wait_for_cancelled(timeout: timedelta | float | None = None) -> bool:
+def wait_for_cancelled(timeout: timedelta | None = None) -> bool:
     """Block until cancellation is requested for this sync activity.
 
     Args:
         timeout: Maximum time to wait. ``None`` waits indefinitely (the server's
             schedule-to-close or heartbeat timeout provides the eventual bound).
-            May be a ``timedelta`` or a number of seconds.
 
     Returns:
         ``True`` if cancellation was requested, ``False`` if the timeout elapsed.
@@ -166,7 +165,7 @@ class ActivityContext(ABC):
     def is_cancelled(self) -> bool: ...
 
     @abstractmethod
-    def wait_for_cancelled(self, timeout: timedelta | float | None = None) -> bool: ...
+    def wait_for_cancelled(self, timeout: timedelta | None = None) -> bool: ...
 
     @contextmanager
     def _activate(self) -> Iterator[None]:

--- a/cadence/metrics/__init__.py
+++ b/cadence/metrics/__init__.py
@@ -8,7 +8,8 @@ from .histogram_buckets import (
     default_buckets_for_metric,
 )
 from .metrics import (
-    duration_between_ns,
+    duration_between,
+    duration_from_nanoseconds,
     MetricsEmitter,
     NoOpMetricsEmitter,
     MetricType,
@@ -21,7 +22,8 @@ __all__ = [
     "LOW_1MS_100S",
     "MID_1MS_24H",
     "default_buckets_for_metric",
-    "duration_between_ns",
+    "duration_between",
+    "duration_from_nanoseconds",
     "MetricsEmitter",
     "NoOpMetricsEmitter",
     "MetricType",

--- a/cadence/metrics/metrics.py
+++ b/cadence/metrics/metrics.py
@@ -1,14 +1,14 @@
 """Core metrics collection interface and registry for Cadence client."""
 
 import logging
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Dict, Optional, Protocol
 
+from google.protobuf.timestamp import to_datetime
 from google.protobuf.timestamp_pb2 import Timestamp
 
 logger = logging.getLogger(__name__)
-
-_NANOSECONDS_PER_SECOND = 1_000_000_000
 
 
 class MetricType(Enum):
@@ -37,21 +37,40 @@ class MetricsEmitter(Protocol):
         ...
 
     def histogram(
-        self, key: str, value: float, tags: Optional[Dict[str, str]] = None
+        self, key: str, value: timedelta, tags: Optional[Dict[str, str]] = None
     ) -> None:
-        """Send a histogram metric."""
+        """Send a duration histogram metric."""
         ...
 
 
-def duration_between_ns(start: Timestamp, end: Timestamp) -> Optional[int]:
-    """Return the duration in nanoseconds between two set timestamps."""
-    if not _timestamp_is_set(start) or not _timestamp_is_set(end):
+def duration_between(
+    start: Timestamp | datetime, end: Timestamp | datetime
+) -> Optional[timedelta]:
+    """Return the duration between two set protobuf timestamps or datetimes."""
+    start_time = _to_datetime(start)
+    end_time = _to_datetime(end)
+    if start_time is None or end_time is None:
         return None
-    return (
-        (int(end.seconds) - int(start.seconds)) * _NANOSECONDS_PER_SECOND
-        + int(end.nanos)
-        - int(start.nanos)
-    )
+    return end_time - start_time
+
+
+def _to_datetime(value: Timestamp | datetime) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value
+    return _timestamp_to_datetime(value)
+
+
+def _timestamp_to_datetime(timestamp: Timestamp) -> Optional[datetime]:
+    """Convert a set protobuf timestamp to a timezone-aware Python datetime."""
+    if not _timestamp_is_set(timestamp):
+        return None
+    result: datetime = to_datetime(timestamp, timezone.utc)
+    return result
+
+
+def duration_from_nanoseconds(nanoseconds: int) -> timedelta:
+    """Convert a monotonic-clock nanosecond delta to Python's duration type."""
+    return timedelta(microseconds=nanoseconds // 1_000)
 
 
 def _timestamp_is_set(timestamp: Timestamp) -> bool:
@@ -79,7 +98,7 @@ class _TaggedEmitter:
         self._base.gauge(key, value, tags={**self._tags, **(tags or {})})
 
     def histogram(
-        self, key: str, value: float, tags: Optional[Dict[str, str]] = None
+        self, key: str, value: timedelta, tags: Optional[Dict[str, str]] = None
     ) -> None:
         self._base.histogram(key, value, tags={**self._tags, **(tags or {})})
 
@@ -101,6 +120,6 @@ class NoOpMetricsEmitter:
         pass
 
     def histogram(
-        self, key: str, value: float, tags: Optional[Dict[str, str]] = None
+        self, key: str, value: timedelta, tags: Optional[Dict[str, str]] = None
     ) -> None:
         pass

--- a/cadence/metrics/prometheus.py
+++ b/cadence/metrics/prometheus.py
@@ -2,6 +2,7 @@
 
 import logging
 from dataclasses import dataclass, field
+from datetime import timedelta
 from typing import Dict, Optional, Sequence
 
 from prometheus_client import (  # type: ignore[import-not-found]
@@ -178,17 +179,18 @@ class PrometheusMetrics(MetricsEmitter):
             logger.error(f"Failed to send gauge {key}: {e}")
 
     def histogram(
-        self, key: str, value: float, tags: Optional[Dict[str, str]] = None
+        self, key: str, value: timedelta, tags: Optional[Dict[str, str]] = None
     ) -> None:
-        """Send a histogram metric."""
+        """Send a duration histogram metric."""
         try:
             histogram = self._get_or_create_histogram(key, tags)
             merged_tags = self._merge_labels(tags)
+            value_ns = _timedelta_to_nanoseconds(value)
 
             if merged_tags:
-                histogram.labels(**merged_tags).observe(value)
+                histogram.labels(**merged_tags).observe(value_ns)
             else:
-                histogram.observe(value)
+                histogram.observe(value_ns)
 
         except Exception as e:
             logger.error(f"Failed to send histogram {key}: {e}")
@@ -201,3 +203,12 @@ class PrometheusMetrics(MetricsEmitter):
         except Exception as e:
             logger.error(f"Failed to generate metrics text: {e}")
             return ""
+
+
+def _timedelta_to_nanoseconds(value: timedelta) -> int:
+    """Convert a Python duration to the nanoseconds used by Cadence metrics."""
+    return (
+        value.days * 86_400_000_000_000
+        + value.seconds * 1_000_000_000
+        + value.microseconds * 1_000
+    )

--- a/cadence/testing/_workflow_environment.py
+++ b/cadence/testing/_workflow_environment.py
@@ -148,7 +148,7 @@ class _InMemoryActivityContext(ActivityContext):
     def is_cancelled(self) -> bool:
         return False
 
-    def wait_for_cancelled(self, timeout: timedelta | float | None = None) -> bool:
+    def wait_for_cancelled(self, timeout: timedelta | None = None) -> bool:
         return False
 
 

--- a/cadence/worker/_activity.py
+++ b/cadence/worker/_activity.py
@@ -92,7 +92,7 @@ class ActivityWorker:
                         ),
                         identity=self._identity,
                     ),
-                    timeout=_LONG_POLL_TIMEOUT,
+                    timeout=_LONG_POLL_TIMEOUT.total_seconds(),
                 )
             )
             self._poll_metrics.record_result(start, task)

--- a/cadence/worker/_decision.py
+++ b/cadence/worker/_decision.py
@@ -93,7 +93,7 @@ class DecisionWorker:
                         ),
                         identity=self._identity,
                     ),
-                    timeout=_LONG_POLL_TIMEOUT,
+                    timeout=_LONG_POLL_TIMEOUT.total_seconds(),
                 )
             )
             self._poll_metrics.record_result(start, task)

--- a/cadence/worker/_decision_task_handler.py
+++ b/cadence/worker/_decision_task_handler.py
@@ -1,14 +1,14 @@
 import asyncio
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 import logging
-from typing import Optional
-
-from google.protobuf.timestamp_pb2 import Timestamp
+from typing import Optional, Sequence
 
 from cadence._internal.workflow.history_event_iterator import iterate_history_events
 from cadence._internal.workflow.memo import memo_from_proto
 from cadence.api.v1.common_pb2 import Payload
+from cadence.api.v1.decision_pb2 import Decision
 from cadence.api.v1.service_worker_pb2 import (
     PollForDecisionTaskResponse,
     RespondDecisionTaskCompletedRequest,
@@ -21,7 +21,11 @@ from cadence.api.v1.query_pb2 import (
 )
 from cadence.api.v1.workflow_pb2 import DecisionTaskFailedCause
 from cadence.client import Client
-from cadence.metrics import duration_between_ns, MetricsEmitter
+from cadence.metrics import (
+    duration_between,
+    duration_from_nanoseconds,
+    MetricsEmitter,
+)
 from cadence.metrics.constants import (
     DECISION_EXECUTION_FAILED_COUNTER,
     DECISION_EXECUTION_LATENCY,
@@ -48,6 +52,13 @@ from cadence.workflow import WorkflowInfo
 from cadence.worker._registry import Registry
 
 logger = logging.getLogger(__name__)
+
+_WORKFLOW_OUTCOME_COUNTERS = {
+    "completed": WORKFLOW_COMPLETED_COUNTER,
+    "failed": WORKFLOW_FAILED_COUNTER,
+    "canceled": WORKFLOW_CANCELED_COUNTER,
+    "continue_as_new": WORKFLOW_CONTINUE_AS_NEW_COUNTER,
+}
 
 
 class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
@@ -199,7 +210,8 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
             raise
         finally:
             emitter.histogram(
-                DECISION_EXECUTION_LATENCY, time.monotonic_ns() - exec_start_ns
+                DECISION_EXECUTION_LATENCY,
+                duration_from_nanoseconds(time.monotonic_ns() - exec_start_ns),
             )
         if is_query_task:
             if not decision_result.query_result:
@@ -207,16 +219,13 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
             await self._respond_query_task_completed(task, decision_result.query_result)
         else:
             await self._respond_decision_task_completed(task, decision_result, emitter)
-            outcome = next(
-                (
-                    o
-                    for d in decision_result.decisions
-                    if (o := _outcome_from_decision(d))
+            self._emit_workflow_outcome_metrics(
+                decision_result.decisions,
+                duration_between(
+                    workflow_events[0].event_time, datetime.now(timezone.utc)
                 ),
-                None,
+                emitter,
             )
-            if outcome is not None:
-                self._emit_workflow_outcome_metrics(outcome, workflow_events, emitter)
 
         logger.info(
             "Successfully processed decision task",
@@ -314,23 +323,25 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
             )
 
     def _emit_workflow_outcome_metrics(
-        self, outcome: str, workflow_events: list, emitter: MetricsEmitter
+        self,
+        decisions: Sequence[Decision],
+        workflow_duration: timedelta | None,
+        emitter: MetricsEmitter,
     ) -> None:
-        counter_map = {
-            "completed": WORKFLOW_COMPLETED_COUNTER,
-            "failed": WORKFLOW_FAILED_COUNTER,
-            "canceled": WORKFLOW_CANCELED_COUNTER,
-            "continue_as_new": WORKFLOW_CONTINUE_AS_NEW_COUNTER,
-        }
-        if counter := counter_map.get(outcome):
-            emitter.counter(counter)
+        outcome = next(
+            (
+                outcome
+                for decision in decisions
+                if (outcome := _outcome_from_decision(decision))
+            ),
+            None,
+        )
+        if outcome is None:
+            return
 
-        if workflow_events:
-            now = Timestamp()
-            now.GetCurrentTime()
-            e2e_latency_ns = duration_between_ns(workflow_events[0].event_time, now)
-            if e2e_latency_ns is not None and e2e_latency_ns >= 0:
-                emitter.histogram(WORKFLOW_END_TO_END_LATENCY, e2e_latency_ns)
+        emitter.counter(_WORKFLOW_OUTCOME_COUNTERS[outcome])
+        if workflow_duration is not None and workflow_duration >= timedelta(0):
+            emitter.histogram(WORKFLOW_END_TO_END_LATENCY, workflow_duration)
 
     async def _respond_decision_task_completed(
         self,
@@ -404,7 +415,8 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
             raise
         finally:
             emitter.histogram(
-                DECISION_RESPONSE_LATENCY, time.monotonic_ns() - resp_start_ns
+                DECISION_RESPONSE_LATENCY,
+                duration_from_nanoseconds(time.monotonic_ns() - resp_start_ns),
             )
 
     async def _respond_query_task_completed(

--- a/cadence/worker/_poll_metrics.py
+++ b/cadence/worker/_poll_metrics.py
@@ -4,6 +4,7 @@ import contextlib
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Protocol
 
 from google.protobuf import timestamp_pb2
@@ -11,7 +12,8 @@ from google.protobuf import timestamp_pb2
 from cadence._internal.rpc.retry import RETRYABLE_CODES
 from cadence.error import CadenceRpcError
 from cadence.metrics import (
-    duration_between_ns,
+    duration_between,
+    duration_from_nanoseconds,
     MetricsEmitter,
 )
 
@@ -48,7 +50,10 @@ class PollMetrics:
             self.emitter.counter(self.failed)
             raise
         finally:
-            self.emitter.histogram(self.latency, time.monotonic_ns() - start)
+            self.emitter.histogram(
+                self.latency,
+                duration_from_nanoseconds(time.monotonic_ns() - start),
+            )
 
     def record_result(self, task: PollTask) -> None:
         """Record succeed vs idle and optional schedule-to-start latency."""
@@ -56,6 +61,6 @@ class PollMetrics:
             self.emitter.counter(self.no_task)
             return
         self.emitter.counter(self.succeed)
-        latency_ns = duration_between_ns(task.scheduled_time, task.started_time)
-        if latency_ns is not None and latency_ns >= 0:
-            self.emitter.histogram(self.scheduled_to_start, latency_ns)
+        latency = duration_between(task.scheduled_time, task.started_time)
+        if latency is not None and latency >= timedelta(0):
+            self.emitter.histogram(self.scheduled_to_start, latency)

--- a/cadence/worker/_types.py
+++ b/cadence/worker/_types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
@@ -29,4 +30,4 @@ _DEFAULT_WORKER_OPTIONS: WorkerOptions = {
     "disable_activity_worker": False,
 }
 
-_LONG_POLL_TIMEOUT = 60.0
+_LONG_POLL_TIMEOUT = timedelta(seconds=60)

--- a/tests/cadence/_internal/activity/test_activity_executor.py
+++ b/tests/cadence/_internal/activity/test_activity_executor.py
@@ -496,7 +496,7 @@ async def test_activity_sync_wait_for_cancelled(client):
     @reg.activity(name="activity_type")
     def activity_fn():
         activity.heartbeat("progress")
-        if activity.wait_for_cancelled(timeout=5):
+        if activity.wait_for_cancelled(timeout=timedelta(seconds=5)):
             raise ActivityCancelledError("cleanup")
         raise AssertionError("expected activity cancellation")
 
@@ -529,7 +529,9 @@ async def test_activity_sync_raise_if_cancelled(client):
     @reg.activity(name="activity_type")
     def activity_fn():
         activity.heartbeat("progress")
-        activity.wait_for_cancelled(timeout=5)  # block until cancel event is set
+        activity.wait_for_cancelled(
+            timeout=timedelta(seconds=5)
+        )  # block until cancel event is set
         activity.raise_if_cancelled()
         raise AssertionError("expected cancellation")
 
@@ -562,7 +564,7 @@ async def test_activity_sync_api_raises_cancelled_after_cancel_request(client):
     @reg.activity(name="activity_type")
     def activity_fn():
         activity.heartbeat("progress")
-        assert activity.wait_for_cancelled(timeout=5)
+        assert activity.wait_for_cancelled(timeout=timedelta(seconds=5))
         activity.info()
         raise AssertionError("expected activity API to raise cancellation")
 

--- a/tests/cadence/_internal/activity/test_activity_executor_metrics.py
+++ b/tests/cadence/_internal/activity/test_activity_executor_metrics.py
@@ -1,6 +1,7 @@
 """Tests for activity execution and response metrics in ActivityExecutor."""
 
 import time
+from datetime import timedelta
 from typing import cast
 import pytest
 from unittest.mock import AsyncMock, Mock, PropertyMock
@@ -143,7 +144,7 @@ class TestActivityExecutionSuccess:
             for c in _tagged(emitter).histogram.call_args_list
             if c.args[0] == ACTIVITY_END_TO_END_LATENCY
         )
-        assert 1e9 < e2e_call.args[1] < 30e9
+        assert timedelta(seconds=1) < e2e_call.args[1] < timedelta(seconds=30)
 
     @pytest.mark.asyncio
     async def test_skips_end_to_end_latency_when_scheduled_time_is_missing(self):

--- a/tests/cadence/_internal/rpc/test_retry.py
+++ b/tests/cadence/_internal/rpc/test_retry.py
@@ -1,4 +1,5 @@
 from concurrent import futures
+from datetime import timedelta
 from typing import Any, Tuple, Type
 
 import pytest
@@ -20,39 +21,75 @@ from cadence.api.v1.service_workflow_pb2 import (
 from cadence.error import CadenceRpcError, FeatureNotEnabledError, EntityNotExistsError
 
 simple_policy = ExponentialRetryPolicy(
-    initial_interval=1, backoff_coefficient=2, max_interval=10, max_attempts=6
+    initial_interval=timedelta(seconds=1),
+    backoff_coefficient=2,
+    max_interval=timedelta(seconds=10),
+    max_attempts=6,
 )
 
 
 @pytest.mark.parametrize(
     "policy,params,expected",
     [
-        pytest.param(simple_policy, (1, 0.0, 100.0), 1, id="happy path"),
-        pytest.param(simple_policy, (2, 0.0, 100.0), 2, id="second attempt"),
-        pytest.param(simple_policy, (3, 0.0, 100.0), 4, id="third attempt"),
-        pytest.param(simple_policy, (5, 0.0, 100.0), 10, id="capped by max_interval"),
-        pytest.param(simple_policy, (6, 0.0, 100.0), None, id="out of attempts"),
-        pytest.param(simple_policy, (1, 100.0, 100.0), None, id="timeout"),
         pytest.param(
-            simple_policy, (1, 99.0, 100.0), None, id="backoff causes timeout"
+            simple_policy,
+            (1, timedelta(0), timedelta(seconds=100)),
+            timedelta(seconds=1),
+            id="happy path",
+        ),
+        pytest.param(
+            simple_policy,
+            (2, timedelta(0), timedelta(seconds=100)),
+            timedelta(seconds=2),
+            id="second attempt",
+        ),
+        pytest.param(
+            simple_policy,
+            (3, timedelta(0), timedelta(seconds=100)),
+            timedelta(seconds=4),
+            id="third attempt",
+        ),
+        pytest.param(
+            simple_policy,
+            (5, timedelta(0), timedelta(seconds=100)),
+            timedelta(seconds=10),
+            id="capped by max_interval",
+        ),
+        pytest.param(
+            simple_policy,
+            (6, timedelta(0), timedelta(seconds=100)),
+            None,
+            id="out of attempts",
+        ),
+        pytest.param(
+            simple_policy,
+            (1, timedelta(seconds=100), timedelta(seconds=100)),
+            None,
+            id="timeout",
+        ),
+        pytest.param(
+            simple_policy,
+            (1, timedelta(seconds=99), timedelta(seconds=100)),
+            None,
+            id="backoff causes timeout",
         ),
         pytest.param(
             ExponentialRetryPolicy(
-                initial_interval=1,
+                initial_interval=timedelta(seconds=1),
                 backoff_coefficient=1,
-                max_interval=10,
+                max_interval=timedelta(seconds=10),
                 max_attempts=0,
             ),
-            (100, 0.0, 100.0),
-            1,
+            (100, timedelta(0), None),
+            timedelta(seconds=1),
             id="unlimited retries",
         ),
     ],
 )
 def test_next_delay(
     policy: ExponentialRetryPolicy,
-    params: Tuple[int, float, float],
-    expected: float | None,
+    params: Tuple[int, timedelta, timedelta | None],
+    expected: timedelta | None,
 ):
     assert policy.next_delay(*params) == expected
 
@@ -124,7 +161,10 @@ def fake_service():
 
 
 TEST_POLICY = ExponentialRetryPolicy(
-    initial_interval=0, backoff_coefficient=0, max_interval=10, max_attempts=10
+    initial_interval=timedelta(0),
+    backoff_coefficient=0,
+    max_interval=timedelta(seconds=10),
+    max_attempts=10,
 )
 
 

--- a/tests/cadence/_internal/rpc/test_retry.py
+++ b/tests/cadence/_internal/rpc/test_retry.py
@@ -6,7 +6,7 @@ import pytest
 from google.protobuf import any_pb2
 from google.rpc import status_pb2, code_pb2
 from grpc import server
-from grpc.aio import insecure_channel
+from grpc.aio import ClientCallDetails, insecure_channel
 from grpc_status.rpc_status import to_status
 
 from cadence._internal.rpc.error import CadenceErrorInterceptor
@@ -230,3 +230,44 @@ async def test_workflow_history(fake_service, case: str, expected_calls: int):
             )
 
         assert fake_service.counter == expected_calls
+
+
+@pytest.mark.asyncio
+async def test_retry_interceptor_clamps_expired_timeout(monkeypatch):
+    class FakeLoop:
+        def __init__(self) -> None:
+            self._times = iter((0, 1))
+
+        def time(self) -> float:
+            return next(self._times)
+
+    class SuccessfulCall:
+        def __await__(self):
+            return self._wait().__await__()
+
+        async def _wait(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "cadence._internal.rpc.retry.asyncio.get_running_loop", lambda: FakeLoop()
+    )
+    timeouts: list[float | None] = []
+
+    async def continuation(call_details, request):
+        timeouts.append(call_details.timeout)
+        return SuccessfulCall()
+
+    result = await RetryInterceptor().intercept_unary_unary(
+        continuation,
+        ClientCallDetails(
+            method="/test",
+            timeout=timedelta(microseconds=1).total_seconds(),
+            metadata=None,
+            credentials=None,
+            wait_for_ready=None,
+        ),
+        None,
+    )
+
+    assert isinstance(result, SuccessfulCall)
+    assert timeouts == [0]

--- a/tests/cadence/_internal/workflow/test_decision_events_iterator.py
+++ b/tests/cadence/_internal/workflow/test_decision_events_iterator.py
@@ -3,6 +3,7 @@
 Tests for Decision Events Iterator.
 """
 
+from datetime import datetime, timezone
 from typing import List
 import pytest
 
@@ -32,7 +33,7 @@ class TestDecisionEventsIterator:
                         "output": 0,
                         "markers": 0,
                         "replay": False,
-                        "replay_time": 3000,
+                        "replay_time": datetime.fromtimestamp(3, tz=timezone.utc),
                         "next_decision_event_id": 5,
                     },
                 ],
@@ -52,7 +53,7 @@ class TestDecisionEventsIterator:
                         "output": 1,
                         "markers": 0,
                         "replay": True,
-                        "replay_time": 4000,
+                        "replay_time": datetime.fromtimestamp(4, tz=timezone.utc),
                         "next_decision_event_id": 5,
                     },
                 ],
@@ -76,7 +77,7 @@ class TestDecisionEventsIterator:
                         "output": 1,
                         "markers": 0,
                         "replay": True,
-                        "replay_time": 4000,
+                        "replay_time": datetime.fromtimestamp(4, tz=timezone.utc),
                         "next_decision_event_id": 5,
                     },
                     {
@@ -84,7 +85,7 @@ class TestDecisionEventsIterator:
                         "output": 0,
                         "markers": 0,
                         "replay": False,
-                        "replay_time": 9000,
+                        "replay_time": datetime.fromtimestamp(9, tz=timezone.utc),
                         "next_decision_event_id": 11,
                     },
                 ],
@@ -103,7 +104,7 @@ class TestDecisionEventsIterator:
             assert len(batch.output) == expect["output"]
             assert len(batch.markers) == expect["markers"]
             assert batch.replay == expect["replay"]
-            assert batch.replay_current_time_milliseconds == expect["replay_time"]
+            assert batch.replay_current_time == expect["replay_time"]
             assert batch.next_decision_event_id == expect["next_decision_event_id"]
 
 
@@ -112,7 +113,7 @@ def create_mock_history_event(event_types: List[str]) -> List[HistoryEvent]:
     for i, event_type in enumerate(event_types):
         event = HistoryEvent()
         event.event_id = i + 1
-        event.event_time.FromMilliseconds((i + 1) * 1000)
+        event.event_time.FromDatetime(datetime.fromtimestamp(i + 1, tz=timezone.utc))
 
         # Set the appropriate attribute based on event type
         if event_type == "decision_task_started":

--- a/tests/cadence/_internal/workflow/test_history_event_iterator.py
+++ b/tests/cadence/_internal/workflow/test_history_event_iterator.py
@@ -7,6 +7,7 @@ from cadence.api.v1.history_pb2 import HistoryEvent, History
 from cadence.api.v1.service_worker_pb2 import PollForDecisionTaskResponse
 from cadence.api.v1.service_workflow_pb2 import GetWorkflowExecutionHistoryResponse
 from cadence._internal.workflow.history_event_iterator import iterate_history_events
+from cadence.metrics import NoOpMetricsEmitter
 
 
 @pytest.fixture
@@ -44,7 +45,10 @@ async def test_iterate_history_events_single_page_no_next_token(
 
     # Iterate and collect events
     result_events = [
-        e async for e in iterate_history_events(decision_task, mock_client)
+        e
+        async for e in iterate_history_events(
+            decision_task, mock_client, NoOpMetricsEmitter()
+        )
     ]
 
     # Verify all events were returned
@@ -70,7 +74,10 @@ async def test_iterate_history_events_empty_events(
 
     # Iterate and collect events
     result_events = [
-        e async for e in iterate_history_events(decision_task, mock_client)
+        e
+        async for e in iterate_history_events(
+            decision_task, mock_client, NoOpMetricsEmitter()
+        )
     ]
 
     # Verify no events were returned
@@ -111,7 +118,10 @@ async def test_iterate_history_events_multiple_pages(
 
     # Iterate and collect events
     result_events = [
-        e async for e in iterate_history_events(decision_task, mock_client)
+        e
+        async for e in iterate_history_events(
+            decision_task, mock_client, NoOpMetricsEmitter()
+        )
     ]
 
     # Verify all events from all pages were returned
@@ -168,7 +178,10 @@ async def test_iterate_history_events_single_page_with_next_token_then_empty(
 
     # Iterate and collect events
     result_events = [
-        e async for e in iterate_history_events(decision_task, mock_client)
+        e
+        async for e in iterate_history_events(
+            decision_task, mock_client, NoOpMetricsEmitter()
+        )
     ]
 
     # Verify only first page events were returned

--- a/tests/cadence/_internal/workflow/test_workflow_engine.py
+++ b/tests/cadence/_internal/workflow/test_workflow_engine.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List
 
 import pytest
@@ -444,7 +444,7 @@ def create_workflow_engine(workflow_definition: WorkflowDefinition) -> WorkflowE
 
 def _event(event_id: int, **attributes) -> HistoryEvent:
     event = HistoryEvent(event_id=event_id)
-    event.event_time.FromMilliseconds(event_id * 1000)
+    event.event_time.FromDatetime(datetime.fromtimestamp(event_id, tz=timezone.utc))
     for name, value in attributes.items():
         getattr(event, name).CopyFrom(value)
     return event

--- a/tests/cadence/metrics/test_metrics.py
+++ b/tests/cadence/metrics/test_metrics.py
@@ -1,11 +1,13 @@
 """Tests for metrics collection functionality."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from cadence.metrics import (
-    duration_between_ns,
+    duration_between,
+    duration_from_nanoseconds,
     MetricsEmitter,
     MetricType,
     NoOpMetricsEmitter,
@@ -26,7 +28,7 @@ class TestMetricsEmitter:
         # Should not raise any exceptions
         emitter.counter("test_counter", 1)
         emitter.gauge("test_gauge", 42.0)
-        emitter.histogram("test_histogram", 0.5)
+        emitter.histogram("test_histogram", timedelta(milliseconds=500))
 
     def test_mock_emitter(self):
         """Test mock emitter implementation."""
@@ -43,9 +45,11 @@ class TestMetricsEmitter:
         mock_emitter.gauge.assert_called_once_with("test_gauge", 100.0, {"env": "test"})
 
         # Test histogram
-        mock_emitter.histogram("test_histogram", 2.5, {"env": "prod"})
+        mock_emitter.histogram(
+            "test_histogram", timedelta(seconds=2, milliseconds=500), {"env": "prod"}
+        )
         mock_emitter.histogram.assert_called_once_with(
-            "test_histogram", 2.5, {"env": "prod"}
+            "test_histogram", timedelta(seconds=2, milliseconds=500), {"env": "prod"}
         )
 
 
@@ -60,24 +64,27 @@ class TestMetricType:
 
 
 class TestDurationMetrics:
-    def test_duration_between_ns_set_timestamps(self):
-        assert (
-            duration_between_ns(
-                _timestamp(seconds=10, nanos=100_000_000),
-                _timestamp(seconds=12, nanos=350_000_000),
-            )
-            == 2_250_000_000
-        )
+    def test_duration_between_set_timestamps(self):
+        assert duration_between(
+            _timestamp(seconds=10, nanos=100_000_000),
+            _timestamp(seconds=12, nanos=350_000_000),
+        ) == timedelta(seconds=2, milliseconds=250)
 
-    def test_duration_between_ns_requires_both_timestamps(self):
-        assert duration_between_ns(_timestamp(), _timestamp(seconds=1)) is None
-        assert duration_between_ns(_timestamp(seconds=1), _timestamp()) is None
+    def test_duration_between_requires_both_timestamps(self):
+        assert duration_between(_timestamp(), _timestamp(seconds=1)) is None
+        assert duration_between(_timestamp(seconds=1), _timestamp()) is None
 
-    def test_duration_between_ns_preserves_clock_skew(self):
-        assert (
-            duration_between_ns(
-                _timestamp(seconds=2),
-                _timestamp(seconds=1),
-            )
-            == -1_000_000_000
-        )
+    def test_duration_between_preserves_clock_skew(self):
+        assert duration_between(
+            _timestamp(seconds=2),
+            _timestamp(seconds=1),
+        ) == -timedelta(seconds=1)
+
+    def test_duration_between_timestamp_and_datetime(self):
+        assert duration_between(
+            _timestamp(seconds=10),
+            datetime.fromtimestamp(12, tz=timezone.utc),
+        ) == timedelta(seconds=2)
+
+    def test_duration_from_nanoseconds_rounds_down_to_microseconds(self):
+        assert duration_from_nanoseconds(2_250_999) == timedelta(microseconds=2_250)

--- a/tests/cadence/metrics/test_prometheus.py
+++ b/tests/cadence/metrics/test_prometheus.py
@@ -1,5 +1,6 @@
 """Tests for Prometheus metrics integration."""
 
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 from cadence.metrics import (
@@ -81,12 +82,18 @@ class TestPrometheusMetrics:
         mock_histogram_class.return_value = mock_histogram
 
         metrics = PrometheusMetrics()
-        metrics.histogram("test_histogram", 1.5, {"type": "latency"})
+        metrics.histogram(
+            "test_histogram",
+            timedelta(seconds=1, milliseconds=500),
+            {"type": "latency"},
+        )
 
         # Verify histogram was created
         mock_histogram_class.assert_called_once()
         mock_histogram.labels.assert_called_once_with(type="latency")
-        mock_histogram.labels.return_value.observe.assert_called_once_with(1.5)
+        mock_histogram.labels.return_value.observe.assert_called_once_with(
+            1_500_000_000
+        )
 
     @patch("cadence.metrics.prometheus.Histogram")
     def test_duration_histogram_uses_default_1ms_100s_buckets(
@@ -94,7 +101,7 @@ class TestPrometheusMetrics:
     ):
         metrics = PrometheusMetrics()
 
-        metrics.histogram("test_latency_ns", 1_000_000_000)
+        metrics.histogram("test_latency_ns", timedelta(seconds=1))
 
         assert mock_histogram_class.call_args.kwargs["buckets"] == tuple(
             DEFAULT_1MS_100S
@@ -106,7 +113,7 @@ class TestPrometheusMetrics:
     ):
         metrics = PrometheusMetrics()
 
-        metrics.histogram("cadence-workflow-endtoend-latency_ns", 1_000_000_000)
+        metrics.histogram("cadence-workflow-endtoend-latency_ns", timedelta(seconds=1))
 
         assert mock_histogram_class.call_args.kwargs["buckets"] == tuple(HIGH_1MS_24H)
 
@@ -118,7 +125,7 @@ class TestPrometheusMetrics:
         config = PrometheusConfig(histogram_buckets={"test_latency_ns": custom_buckets})
         metrics = PrometheusMetrics(config)
 
-        metrics.histogram("test_latency_ns", 1_000_000_000)
+        metrics.histogram("test_latency_ns", timedelta(seconds=1))
 
         assert mock_histogram_class.call_args.kwargs["buckets"] == custom_buckets
 
@@ -128,7 +135,7 @@ class TestPrometheusMetrics:
         config = PrometheusConfig(duration_bucket_resolver=lambda name: custom_buckets)
         metrics = PrometheusMetrics(config)
 
-        metrics.histogram("test_latency_ns", 1_000_000_000)
+        metrics.histogram("test_latency_ns", timedelta(seconds=1))
 
         assert mock_histogram_class.call_args.kwargs["buckets"] == custom_buckets
 

--- a/tests/cadence/worker/test_execution_metrics.py
+++ b/tests/cadence/worker/test_execution_metrics.py
@@ -1,7 +1,7 @@
 """Tests for decision task execution and workflow lifecycle metrics."""
 
 import asyncio
-import time
+from datetime import timedelta
 from typing import cast
 import pytest
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
@@ -383,9 +383,15 @@ class TestDecisionPanicAndLifecycleMetrics:
     def test_emits_completed_counter_for_completed_outcome(self):
         emitter = _mock_emitter()
         handler = _make_handler(emitter)
-        events = [_make_started_event(event_time_seconds=0)]
-
-        handler._emit_workflow_outcome_metrics("completed", events, emitter)
+        handler._emit_workflow_outcome_metrics(
+            [
+                Decision(
+                    complete_workflow_execution_decision_attributes=CompleteWorkflowExecutionDecisionAttributes()
+                )
+            ],
+            None,
+            emitter,
+        )
 
         counter_names = [c.args[0] for c in emitter.counter.call_args_list]
         assert WORKFLOW_COMPLETED_COUNTER in counter_names
@@ -393,30 +399,56 @@ class TestDecisionPanicAndLifecycleMetrics:
     def test_emits_failed_counter_for_failed_outcome(self):
         emitter = _mock_emitter()
         handler = _make_handler(emitter)
-        handler._emit_workflow_outcome_metrics("failed", [], emitter)
+        handler._emit_workflow_outcome_metrics(
+            [
+                Decision(
+                    fail_workflow_execution_decision_attributes=FailWorkflowExecutionDecisionAttributes()
+                )
+            ],
+            None,
+            emitter,
+        )
         counter_names = [c.args[0] for c in emitter.counter.call_args_list]
         assert WORKFLOW_FAILED_COUNTER in counter_names
 
     def test_emits_canceled_counter_for_canceled_outcome(self):
         emitter = _mock_emitter()
         handler = _make_handler(emitter)
-        handler._emit_workflow_outcome_metrics("canceled", [], emitter)
+        handler._emit_workflow_outcome_metrics(
+            [Decision(cancel_workflow_execution_decision_attributes={})],
+            None,
+            emitter,
+        )
         counter_names = [c.args[0] for c in emitter.counter.call_args_list]
         assert WORKFLOW_CANCELED_COUNTER in counter_names
 
     def test_emits_continue_as_new_counter(self):
         emitter = _mock_emitter()
         handler = _make_handler(emitter)
-        handler._emit_workflow_outcome_metrics("continue_as_new", [], emitter)
+        handler._emit_workflow_outcome_metrics(
+            [
+                Decision(
+                    continue_as_new_workflow_execution_decision_attributes=ContinueAsNewWorkflowExecutionDecisionAttributes()
+                )
+            ],
+            None,
+            emitter,
+        )
         counter_names = [c.args[0] for c in emitter.counter.call_args_list]
         assert WORKFLOW_CONTINUE_AS_NEW_COUNTER in counter_names
 
     def test_emits_end_to_end_latency_when_event_time_set(self):
         emitter = _mock_emitter()
         handler = _make_handler(emitter)
-        started = _make_started_event(event_time_seconds=int(time.time()) - 10)
-
-        handler._emit_workflow_outcome_metrics("completed", [started], emitter)
+        handler._emit_workflow_outcome_metrics(
+            [
+                Decision(
+                    complete_workflow_execution_decision_attributes=CompleteWorkflowExecutionDecisionAttributes()
+                )
+            ],
+            timedelta(seconds=10),
+            emitter,
+        )
 
         histogram_names = [c.args[0] for c in emitter.histogram.call_args_list]
         assert WORKFLOW_END_TO_END_LATENCY in histogram_names
@@ -425,14 +457,20 @@ class TestDecisionPanicAndLifecycleMetrics:
             for c in emitter.histogram.call_args_list
             if c.args[0] == WORKFLOW_END_TO_END_LATENCY
         )
-        assert 5e9 < latency_call.args[1] < 20e9
+        assert timedelta(seconds=5) < latency_call.args[1] < timedelta(seconds=20)
 
     def test_no_end_to_end_latency_when_event_time_zero(self):
         emitter = _mock_emitter()
         handler = _make_handler(emitter)
-        started = _make_started_event(event_time_seconds=0)
-
-        handler._emit_workflow_outcome_metrics("completed", [started], emitter)
+        handler._emit_workflow_outcome_metrics(
+            [
+                Decision(
+                    complete_workflow_execution_decision_attributes=CompleteWorkflowExecutionDecisionAttributes()
+                )
+            ],
+            None,
+            emitter,
+        )
 
         histogram_names = [c.args[0] for c in emitter.histogram.call_args_list]
         assert WORKFLOW_END_TO_END_LATENCY not in histogram_names

--- a/tests/cadence/worker/test_poll_metrics.py
+++ b/tests/cadence/worker/test_poll_metrics.py
@@ -203,7 +203,7 @@ class TestDecisionWorkerPollMetrics:
         histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
         assert DECISION_SCHEDULED_TO_START_LATENCY in histogram_calls
         latency_call = histogram_calls[DECISION_SCHEDULED_TO_START_LATENCY]
-        assert latency_call.args[1] == 2_000_000_000
+        assert latency_call.args[1] == timedelta(seconds=2)
 
     @pytest.mark.asyncio
     async def test_no_scheduled_to_start_when_timestamps_zero(self):
@@ -412,10 +412,9 @@ class TestActivityWorkerPollMetrics:
 
         histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
         assert ACTIVITY_SCHEDULED_TO_START_LATENCY in histogram_calls
-        assert (
-            histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1]
-            == 3_000_000_000
-        )
+        assert histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[
+            1
+        ] == timedelta(seconds=3)
 
     @pytest.mark.asyncio
     async def test_emits_scheduled_to_start_latency_when_only_nanos_set(self):
@@ -431,9 +430,9 @@ class TestActivityWorkerPollMetrics:
         await worker._poll()
 
         histogram_calls = {c.args[0]: c for c in emitter.histogram.call_args_list}
-        assert (
-            histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[1] == 200_000_000
-        )
+        assert histogram_calls[ACTIVITY_SCHEDULED_TO_START_LATENCY].args[
+            1
+        ] == timedelta(milliseconds=200)
 
     @pytest.mark.asyncio
     async def test_emits_transient_failed_counter_on_retryable_error(self):

--- a/tests/cadence/worker/test_poll_metrics.py
+++ b/tests/cadence/worker/test_poll_metrics.py
@@ -1,5 +1,6 @@
 """Tests for poll and worker-start metrics in DecisionWorker and ActivityWorker."""
 
+from datetime import datetime, timedelta, timezone
 import pytest
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -71,10 +72,12 @@ def _worker_options(emitter) -> WorkerOptions:
     }
 
 
-def _make_ts(seconds: int, nanos: int = 0) -> Timestamp:
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _make_ts(when: datetime) -> Timestamp:
     ts = Timestamp()
-    ts.seconds = seconds
-    ts.nanos = nanos
+    ts.FromDatetime(when)
     return ts
 
 
@@ -171,8 +174,8 @@ class TestDecisionWorkerPollMetrics:
         client = _mock_client()
         mock_task = Mock()
         mock_task.task_token = b"token"
-        mock_task.scheduled_time = _make_ts(0)
-        mock_task.started_time = _make_ts(0)
+        mock_task.scheduled_time = _make_ts(_EPOCH)
+        mock_task.started_time = _make_ts(_EPOCH)
         client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
         worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
@@ -190,8 +193,8 @@ class TestDecisionWorkerPollMetrics:
         client = _mock_client()
         mock_task = Mock()
         mock_task.task_token = b"token"
-        mock_task.scheduled_time = _make_ts(1000)
-        mock_task.started_time = _make_ts(1002)
+        mock_task.scheduled_time = _make_ts(_EPOCH + timedelta(seconds=1000))
+        mock_task.started_time = _make_ts(_EPOCH + timedelta(seconds=1002))
         client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
         worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
@@ -208,8 +211,8 @@ class TestDecisionWorkerPollMetrics:
         client = _mock_client()
         mock_task = Mock()
         mock_task.task_token = b"token"
-        mock_task.scheduled_time = _make_ts(0)
-        mock_task.started_time = _make_ts(0)
+        mock_task.scheduled_time = _make_ts(_EPOCH)
+        mock_task.started_time = _make_ts(_EPOCH)
         client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
         worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
@@ -224,8 +227,8 @@ class TestDecisionWorkerPollMetrics:
         client = _mock_client()
         mock_task = Mock()
         mock_task.task_token = b"token"
-        mock_task.scheduled_time = _make_ts(1002)
-        mock_task.started_time = _make_ts(1000)
+        mock_task.scheduled_time = _make_ts(_EPOCH + timedelta(seconds=1002))
+        mock_task.started_time = _make_ts(_EPOCH + timedelta(seconds=1000))
         client.worker_stub.PollForDecisionTask = AsyncMock(return_value=mock_task)
         worker = DecisionWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
@@ -364,8 +367,8 @@ class TestActivityWorkerPollMetrics:
         client = _mock_client()
         mock_task = Mock()
         mock_task.task_token = b"token"
-        mock_task.scheduled_time = _make_ts(0)
-        mock_task.started_time = _make_ts(0)
+        mock_task.scheduled_time = _make_ts(_EPOCH)
+        mock_task.started_time = _make_ts(_EPOCH)
         client.worker_stub.PollForActivityTask = AsyncMock(return_value=mock_task)
         worker = ActivityWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
@@ -383,8 +386,8 @@ class TestActivityWorkerPollMetrics:
         client = _mock_client()
         mock_task = Mock()
         mock_task.task_token = b"token"
-        mock_task.scheduled_time = _make_ts(500)
-        mock_task.started_time = _make_ts(503)
+        mock_task.scheduled_time = _make_ts(_EPOCH + timedelta(seconds=500))
+        mock_task.started_time = _make_ts(_EPOCH + timedelta(seconds=503))
         client.worker_stub.PollForActivityTask = AsyncMock(return_value=mock_task)
         worker = ActivityWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 
@@ -403,8 +406,8 @@ class TestActivityWorkerPollMetrics:
         client = _mock_client()
         mock_task = Mock()
         mock_task.task_token = b"token"
-        mock_task.scheduled_time = _make_ts(0, 100_000_000)
-        mock_task.started_time = _make_ts(0, 300_000_000)
+        mock_task.scheduled_time = _make_ts(_EPOCH + timedelta(milliseconds=100))
+        mock_task.started_time = _make_ts(_EPOCH + timedelta(milliseconds=300))
         client.worker_stub.PollForActivityTask = AsyncMock(return_value=mock_task)
         worker = ActivityWorker(client, TASK_LIST, Registry(), _worker_options(emitter))
 

--- a/tests/integration_tests/workflow/test_heartbeat.py
+++ b/tests/integration_tests/workflow/test_heartbeat.py
@@ -2,7 +2,6 @@ import asyncio
 import time
 from datetime import timedelta
 
-import pytest
 
 from cadence import workflow, Registry, activity
 from cadence.error import ActivityCancelledError
@@ -46,14 +45,11 @@ class HeartbeatWorkflow:
 
 
 @registry.activity()
-def sync_wait_cancel_activity(timeout_kind: str) -> str:
-    """Sync activity using ``wait_for_cancelled`` with timedelta or float timeouts."""
+def sync_wait_cancel_activity() -> str:
+    """Sync activity using ``wait_for_cancelled`` with a typed timeout."""
     while True:
         activity.heartbeat("waiting")
-        if timeout_kind == "timedelta":
-            cancelled = activity.wait_for_cancelled(timedelta(milliseconds=300))
-        else:
-            cancelled = activity.wait_for_cancelled(0.3)
+        cancelled = activity.wait_for_cancelled(timedelta(milliseconds=300))
         if cancelled:
             raise ActivityCancelledError("bye")
         time.sleep(0.05)
@@ -62,13 +58,13 @@ def sync_wait_cancel_activity(timeout_kind: str) -> str:
 @registry.workflow()
 class SyncWaitForCancelledWorkflow:
     @workflow.run
-    async def run(self, timeout_kind: str) -> str:
+    async def run(self) -> str:
         activity_task = asyncio.create_task(
             sync_wait_cancel_activity.with_options(
                 schedule_to_close_timeout=timedelta(seconds=30),
                 start_to_close_timeout=timedelta(seconds=30),
                 heartbeat_timeout=timedelta(seconds=2),
-            ).execute(timeout_kind)
+            ).execute()
         )
 
         await workflow.sleep(timedelta(seconds=1))
@@ -242,15 +238,11 @@ async def test_activity_cancellation_is_delivered_by_heartbeat(
         assert cancel_requested_events
 
 
-@pytest.mark.parametrize("timeout_kind", ["timedelta", "float"])
-async def test_sync_wait_for_cancelled_with_timedelta_or_float_timeout(
-    helper: CadenceHelper, timeout_kind: str
-):
-    """Integration: sync ``wait_for_cancelled`` accepts timedelta or float timeouts."""
+async def test_sync_wait_for_cancelled(helper: CadenceHelper):
+    """Integration: sync ``wait_for_cancelled`` accepts a typed timeout."""
     async with helper.worker(registry) as worker:
         execution = await worker.client.start_workflow(
             "SyncWaitForCancelledWorkflow",
-            timeout_kind,
             task_list=worker.task_list,
             execution_start_to_close_timeout=timedelta(seconds=30),
         )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactored metrics to use timedelta instead of raw nanosecond int/float values.
To keep things pythonic, time within the client are passed in form of timedelta while they got translated into protobuf Timestamp in API layer.

<!-- Tell your future self why have you made these changes -->
**Why?**
we want to avoid confusion for metrics regarding to time and duration

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**