### PR TITLE
feat: mutable side_effect feature

### DIFF
--- a/cadence/_internal/workflow/context.py
+++ b/cadence/_internal/workflow/context.py
@@ -285,6 +285,54 @@ class Context(WorkflowContext):
             self.data_converter().from_data(result_payload, [result_type])[0],
         )
 
+    def mutable_side_effect(
+        self,
+        id: str,
+        fn: Callable[[], ResultType],
+        result_type: Type[ResultType],
+        updated: Callable[[ResultType, ResultType], bool],
+    ) -> ResultType:
+        """Return a non-deterministic value, recording it only when it changes."""
+        if not id:
+            raise ValueError("id must not be empty")
+
+        access_count, stored_payload, has_history_update = (
+            self._decision_manager.mutable_side_effect_value(id)
+        )
+        if self.is_replay_mode():
+            if stored_payload is None:
+                raise ValueError(
+                    "No recorded value for mutable_side_effect "
+                    f"id={id!r} at access count {access_count}"
+                )
+            if has_history_update:
+                stored_payload = self._decision_manager.record_mutable_side_effect(
+                    id, access_count, Payload()
+                )
+            return cast(
+                ResultType,
+                self.data_converter().from_data(stored_payload, [result_type])[0],
+            )
+
+        value = fn()
+        if stored_payload is not None:
+            stored_value = cast(
+                ResultType,
+                self.data_converter().from_data(stored_payload, [result_type])[0],
+            )
+            if not updated(stored_value, value):
+                return stored_value
+
+        result_payload = self._decision_manager.record_mutable_side_effect(
+            id,
+            access_count,
+            self.data_converter().to_data([value]),
+        )
+        return cast(
+            ResultType,
+            self.data_converter().from_data(result_payload, [result_type])[0],
+        )
+
     def set_replay_current_time(self, current_time: datetime) -> None:
         """Set the current replay timestamp."""
         self._replay_current_time = current_time

--- a/cadence/_internal/workflow/statemachine/decision_manager.py
+++ b/cadence/_internal/workflow/statemachine/decision_manager.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from collections import OrderedDict
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, Type, ClassVar, List, Iterator
 
 from cadence._internal.workflow.statemachine.activity_state_machine import (
@@ -31,6 +31,7 @@ from cadence._internal.workflow.statemachine.event_dispatcher import (
     resolve_id_attr,
 )
 from cadence._internal.workflow.statemachine.marker_state_machine import (
+    MUTABLE_SIDE_EFFECT_MARKER_NAME,
     encode_marker_header,
     marker_context_id,
     marker_decision_id,
@@ -38,6 +39,7 @@ from cadence._internal.workflow.statemachine.marker_state_machine import (
     MARKER_HEADER_KEY,
     marker_events,
     MarkerStateMachine,
+    mutable_side_effect_marker_info,
 )
 from cadence._internal.workflow.statemachine.nondeterminism import DeterminismTracker
 from cadence._internal.workflow.statemachine.cancellation import is_immediate_cancel
@@ -66,6 +68,18 @@ def _consume_future_exception(future: asyncio.Future[Any]) -> None:
 class EventDispatch:
     decision_type: DecisionType
     action: Action
+
+
+@dataclass
+class MutableSideEffectState:
+    access_count: int = 0
+    value: Payload | None = None
+    updates: dict[int, Payload] = field(default_factory=dict)
+
+
+def _mutable_side_effect_context_id(side_effect_id: str, access_count: int) -> str:
+    """Return a stable marker context ID without consuming a decision ID."""
+    return f"mutable-side-effect:{side_effect_id}:{access_count}"
 
 
 def _create_dispatch_map(
@@ -108,6 +122,7 @@ class DecisionManager:
         self._determinism_tracker = DeterminismTracker()
         self._replaying = False
         self._recorded_marker_details: Dict[DecisionId, Payload] = {}
+        self._mutable_side_effects: dict[str, MutableSideEffectState] = {}
         self.state_machines: OrderedDict[DecisionId, DecisionStateMachine] = (
             OrderedDict()
         )
@@ -185,14 +200,29 @@ class DecisionManager:
         self,
         attrs: decision.RecordMarkerDecisionAttributes,
     ) -> Payload:
+        return self._record_marker(attrs)
+
+    def _record_marker(
+        self,
+        attrs: decision.RecordMarkerDecisionAttributes,
+        *,
+        context_id: str | None = None,
+        mutable_side_effect_id: str | None = None,
+        mutable_side_effect_access_count: int | None = None,
+    ) -> Payload:
         if not attrs.marker_name:
             raise ValueError("marker_name is required")
-        context_id = self._next_id()
+        if context_id is None:
+            context_id = self._next_id()
 
         # Metadata (the context_id) goes in the Header; Details stays the raw user payload.
         # The header is set in-place so the state machine carries it on the wire.
         attrs.header.fields[MARKER_HEADER_KEY].CopyFrom(
-            encode_marker_header(context_id)
+            encode_marker_header(
+                context_id,
+                mutable_side_effect_id=mutable_side_effect_id,
+                mutable_side_effect_access_count=mutable_side_effect_access_count,
+            )
         )
 
         marker_id = marker_decision_id(attrs.marker_name, context_id)
@@ -206,6 +236,50 @@ class DecisionManager:
 
         machine = MarkerStateMachine(attrs, attrs.marker_name, context_id)
         self._add_state_machine(machine)
+        return result
+
+    def mutable_side_effect_value(
+        self, side_effect_id: str
+    ) -> tuple[int, Payload | None, bool]:
+        """Return the recorded value for this mutable-side-effect invocation.
+
+        During replay, a preloaded marker update is applied only at its original
+        per-ID invocation count. Calls without an update reuse the latest value.
+        """
+        state = self._mutable_side_effects.setdefault(
+            side_effect_id, MutableSideEffectState()
+        )
+        access_count = state.access_count
+        state.access_count += 1
+        update = state.updates.get(access_count)
+        if self._replaying and update is not None:
+            state.value = update
+        return (
+            access_count,
+            state.value,
+            update is not None,
+        )
+
+    def record_mutable_side_effect(
+        self,
+        side_effect_id: str,
+        access_count: int,
+        details: Payload,
+    ) -> Payload:
+        """Record a changed mutable-side-effect value and update its cache."""
+        result = self._record_marker(
+            decision.RecordMarkerDecisionAttributes(
+                marker_name=MUTABLE_SIDE_EFFECT_MARKER_NAME,
+                details=details,
+            ),
+            context_id=_mutable_side_effect_context_id(side_effect_id, access_count),
+            mutable_side_effect_id=side_effect_id,
+            mutable_side_effect_access_count=access_count,
+        )
+        state = self._mutable_side_effects.setdefault(
+            side_effect_id, MutableSideEffectState()
+        )
+        state.value = result
         return result
 
     # ----- Workflow API -----
@@ -341,7 +415,15 @@ class DecisionManager:
         if context_id is None:
             return
         marker_id = marker_decision_id(attrs.marker_name, context_id)
-        self._recorded_marker_details[marker_id] = Payload(data=attrs.details.data)
+        details = Payload(data=attrs.details.data)
+        self._recorded_marker_details[marker_id] = details
+        mutable_info = mutable_side_effect_marker_info(attrs)
+        if mutable_info is not None:
+            side_effect_id, access_count = mutable_info
+            state = self._mutable_side_effects.setdefault(
+                side_effect_id, MutableSideEffectState()
+            )
+            state.updates[access_count] = details
 
     # ---- Non-determinism ----
     @contextmanager

--- a/cadence/_internal/workflow/statemachine/marker_state_machine.py
+++ b/cadence/_internal/workflow/statemachine/marker_state_machine.py
@@ -37,13 +37,43 @@ MARKER_HEADER_KEY = "MarkerHeader"
 marker_events = EventDispatcher()
 
 
-class MarkerHeader(Struct):
+class MarkerHeader(Struct, omit_defaults=True):
     context_id: str
+    mutable_side_effect_id: str | None = None
+    mutable_side_effect_access_count: int | None = None
 
 
-def encode_marker_header(context_id: str) -> Payload:
+def encode_marker_header(
+    context_id: str,
+    *,
+    mutable_side_effect_id: str | None = None,
+    mutable_side_effect_access_count: int | None = None,
+) -> Payload:
     """Serialize marker metadata for storage under MARKER_HEADER_KEY."""
-    return Payload(data=json.encode(MarkerHeader(context_id=context_id)))
+    return Payload(
+        data=json.encode(
+            MarkerHeader(
+                context_id=context_id,
+                mutable_side_effect_id=mutable_side_effect_id,
+                mutable_side_effect_access_count=mutable_side_effect_access_count,
+            )
+        )
+    )
+
+
+def marker_header(
+    attrs: decision.RecordMarkerDecisionAttributes
+    | history.MarkerRecordedEventAttributes,
+) -> MarkerHeader | None:
+    """Decode the marker header, returning None for foreign markers."""
+    if MARKER_HEADER_KEY not in attrs.header.fields:
+        return None
+    try:
+        return json.decode(
+            attrs.header.fields[MARKER_HEADER_KEY].data, type=MarkerHeader
+        )
+    except DecodeError:
+        return None
 
 
 def marker_context_id(
@@ -56,14 +86,28 @@ def marker_context_id(
     marker upstream, so None is a defensive fallback for a missing/malformed header, not
     a case hit in normal replay.
     """
-    if MARKER_HEADER_KEY not in attrs.header.fields:
+    header = marker_header(attrs)
+    return header.context_id if header is not None else None
+
+
+def mutable_side_effect_marker_info(
+    attrs: decision.RecordMarkerDecisionAttributes
+    | history.MarkerRecordedEventAttributes,
+) -> tuple[str, int] | None:
+    """Return a mutable side effect marker's stable ID and invocation count."""
+    if attrs.marker_name != MUTABLE_SIDE_EFFECT_MARKER_NAME:
         return None
-    try:
-        return json.decode(
-            attrs.header.fields[MARKER_HEADER_KEY].data, type=MarkerHeader
-        ).context_id
-    except DecodeError:
+    header = marker_header(attrs)
+    if (
+        header is None
+        or header.mutable_side_effect_id is None
+        or header.mutable_side_effect_access_count is None
+    ):
         return None
+    return (
+        header.mutable_side_effect_id,
+        header.mutable_side_effect_access_count,
+    )
 
 
 def marker_decision_id(marker_name: str, context_id: str) -> DecisionId:

--- a/cadence/_internal/workflow/statemachine/nondeterminism.py
+++ b/cadence/_internal/workflow/statemachine/nondeterminism.py
@@ -18,6 +18,7 @@ from cadence._internal.workflow.statemachine.decision_state_machine import (
 from cadence._internal.workflow.statemachine.marker_state_machine import (
     marker_context_id,
     marker_decision_id,
+    MUTABLE_SIDE_EFFECT_MARKER_NAME,
     VERSION_MARKER_NAME,
 )
 from cadence.api.v1 import decision, history
@@ -367,8 +368,9 @@ def _(
 # via the DecisionId alone; the Expectation body is empty since the DecisionId already
 # captures both the type and the identity.
 #
-# Version markers are exempt: adding/removing a version check is always safe, so both
-# handlers return None (no expectation on either side). This matches Go SDK behaviour.
+# Version and mutable side-effect markers are exempt from generic decision matching.
+# They have specialized replay caches, so adding/removing an invocation does not shift
+# ordinary decision matching. This matches Go SDK behaviour.
 #
 # Details are intentionally excluded from Expectation; DecisionManager stores recorded
 # values in _recorded_marker_details and returns the historical value on replay directly.
@@ -377,7 +379,7 @@ def _(attrs: decision.RecordMarkerDecisionAttributes) -> Expectation | None:
     context_id = marker_context_id(attrs)
     if context_id is None:
         return None
-    if attrs.marker_name == VERSION_MARKER_NAME:
+    if attrs.marker_name in {VERSION_MARKER_NAME, MUTABLE_SIDE_EFFECT_MARKER_NAME}:
         return None
     return Expectation(marker_decision_id(attrs.marker_name, context_id), {})
 
@@ -387,7 +389,7 @@ def _(attrs: history.MarkerRecordedEventAttributes) -> Expectation | None:
     context_id = marker_context_id(attrs)
     if context_id is None:
         return None
-    if attrs.marker_name == VERSION_MARKER_NAME:
+    if attrs.marker_name in {VERSION_MARKER_NAME, MUTABLE_SIDE_EFFECT_MARKER_NAME}:
         return None
     return Expectation(marker_decision_id(attrs.marker_name, context_id), {})
 

--- a/cadence/testing/_workflow_environment.py
+++ b/cadence/testing/_workflow_environment.py
@@ -164,6 +164,7 @@ class _InMemoryWorkflowContext(WorkflowContext):
     def __init__(self, env: "TestWorkflowEnvironment", info: WorkflowInfo) -> None:
         self._env = env
         self._info = info
+        self._mutable_side_effect_values: dict[str, Any] = {}
 
     def info(self) -> WorkflowInfo:
         return self._info
@@ -223,6 +224,26 @@ class _InMemoryWorkflowContext(WorkflowContext):
         result_type: Type[ResultType],
     ) -> ResultType:
         return fn()
+
+    def mutable_side_effect(
+        self,
+        id: str,
+        fn: Callable[[], ResultType],
+        result_type: Type[ResultType],
+        updated: Callable[[ResultType, ResultType], bool],
+    ) -> ResultType:
+        if not id:
+            raise ValueError("id must not be empty")
+        value = fn()
+        if id not in self._mutable_side_effect_values:
+            self._mutable_side_effect_values[id] = value
+            return value
+
+        previous = cast(ResultType, self._mutable_side_effect_values[id])
+        if updated(previous, value):
+            self._mutable_side_effect_values[id] = value
+            return value
+        return previous
 
     async def signal_child_workflow(
         self,

--- a/cadence/workflow.py
+++ b/cadence/workflow.py
@@ -199,6 +199,21 @@ def side_effect(
     return WorkflowContext.get().side_effect(fn, result_type)
 
 
+def mutable_side_effect(
+    id: str,
+    fn: Callable[[], ResultType],
+    result_type: Type[ResultType],
+    updated: Callable[[ResultType, ResultType], bool],
+) -> ResultType:
+    """Return a non-deterministic value, recording it only when it changes.
+
+    ``id`` must remain stable for the workflow execution. ``updated`` receives
+    the previously recorded value and the new value, and returns whether the new
+    value should be persisted. During replay, neither callback is invoked.
+    """
+    return WorkflowContext.get().mutable_side_effect(id, fn, result_type, updated)
+
+
 def is_cancel_requested() -> bool:
     return WorkflowContext.get().is_cancel_requested()
 
@@ -623,6 +638,15 @@ class WorkflowContext(ABC):
         self,
         fn: Callable[[], ResultType],
         result_type: Type[ResultType],
+    ) -> ResultType: ...
+
+    @abstractmethod
+    def mutable_side_effect(
+        self,
+        id: str,
+        fn: Callable[[], ResultType],
+        result_type: Type[ResultType],
+        updated: Callable[[ResultType, ResultType], bool],
     ) -> ResultType: ...
 
     @abstractmethod

--- a/tests/cadence/_internal/workflow/statemachine/test_decision_manager.py
+++ b/tests/cadence/_internal/workflow/statemachine/test_decision_manager.py
@@ -13,6 +13,7 @@ from cadence._internal.workflow.statemachine.event_dispatcher import (
 from cadence._internal.workflow.statemachine.marker_state_machine import (
     encode_marker_header,
     MARKER_HEADER_KEY,
+    mutable_side_effect_marker_info,
 )
 from cadence._internal.workflow.statemachine.nondeterminism import NonDeterminismError
 from cadence._internal.workflow.statemachine.signal_external_workflow_state_machine import (
@@ -354,6 +355,72 @@ async def test_record_marker_requires_marker_name():
     assert decisions.collect_pending_decisions() == []
 
 
+async def test_mutable_side_effect_records_metadata_and_caches_value():
+    decisions = DecisionManager(asyncio.get_event_loop())
+    access_count, stored, has_history_update = decisions.mutable_side_effect_value(
+        "config"
+    )
+
+    assert (access_count, stored, has_history_update) == (0, None, False)
+    decisions.record_mutable_side_effect("config", access_count, Payload(data=b"value"))
+
+    emitted = decisions.collect_pending_decisions()[0]
+    attrs = emitted.record_marker_decision_attributes
+    assert mutable_side_effect_marker_info(attrs) == ("config", 0)
+    assert attrs.details == Payload(data=b"value")
+
+    _, stored, has_history_update = decisions.mutable_side_effect_value("config")
+    assert stored == Payload(data=b"value")
+    assert has_history_update is False
+
+
+async def test_mutable_side_effect_does_not_shift_other_decision_ids_on_replay():
+    decisions = DecisionManager(asyncio.get_event_loop())
+    recorded = marker_recorded(
+        1,
+        "MutableSideEffect",
+        Payload(data=b"history-value"),
+        context_id="mutable-side-effect:config:0",
+        mutable_side_effect_id="config",
+        mutable_side_effect_access_count=0,
+    )
+
+    with decisions.track_nondeterminism(True, [recorded, activity_scheduled(2, "0")]):
+        access_count, _, has_history_update = decisions.mutable_side_effect_value(
+            "config"
+        )
+        assert has_history_update is True
+        decisions.record_mutable_side_effect("config", access_count, Payload())
+        decisions.schedule_activity(decision.ScheduleActivityTaskDecisionAttributes())
+
+
+async def test_mutable_side_effect_replay_applies_marker_at_matching_access_count():
+    decisions = DecisionManager(asyncio.get_event_loop())
+    recorded = marker_recorded(
+        1,
+        "MutableSideEffect",
+        Payload(data=b"history-value"),
+        context_id="0",
+        mutable_side_effect_id="config",
+        mutable_side_effect_access_count=1,
+    )
+
+    with decisions.track_nondeterminism(True, [recorded]):
+        first_access, first_value, first_update = decisions.mutable_side_effect_value(
+            "config"
+        )
+        second_access, second_value, second_update = (
+            decisions.mutable_side_effect_value("config")
+        )
+
+    assert (first_access, first_value, first_update) == (0, None, False)
+    assert (second_access, second_value, second_update) == (
+        1,
+        Payload(data=b"history-value"),
+        True,
+    )
+
+
 async def test_cancel_marker_is_not_logged_as_unknown_marker_name(caplog):
     # The immediate-cancellation marker (cancellation.py) is Python-specific and encodes
     # a JSON object in Details, not a [context_id, user_data] pair. It must not be mistaken
@@ -654,7 +721,13 @@ def activity_completed(
 
 
 def marker_recorded(
-    event_id: int, marker_name: str, details: Payload, context_id: str | None = None
+    event_id: int,
+    marker_name: str,
+    details: Payload,
+    context_id: str | None = None,
+    *,
+    mutable_side_effect_id: str | None = None,
+    mutable_side_effect_access_count: int | None = None,
 ) -> history.HistoryEvent:
     attrs = history.MarkerRecordedEventAttributes(
         marker_name=marker_name,
@@ -662,7 +735,11 @@ def marker_recorded(
     )
     if context_id is not None:
         attrs.header.fields[MARKER_HEADER_KEY].CopyFrom(
-            encode_marker_header(context_id)
+            encode_marker_header(
+                context_id,
+                mutable_side_effect_id=mutable_side_effect_id,
+                mutable_side_effect_access_count=mutable_side_effect_access_count,
+            )
         )
     return history.HistoryEvent(
         event_id=event_id,

--- a/tests/cadence/_internal/workflow/test_context_side_effect.py
+++ b/tests/cadence/_internal/workflow/test_context_side_effect.py
@@ -129,3 +129,96 @@ def test_side_effect_module_level_dispatches_through_context():
 
     assert result == 7
     dm.record_marker.assert_called_once()
+
+
+def test_mutable_side_effect_records_first_value():
+    ctx, dm = _make_ctx()
+    dc = _dc()
+    dm.mutable_side_effect_value.return_value = (0, None, False)
+    dm.record_mutable_side_effect.return_value = dc.to_data(["first"])
+
+    result = ctx.mutable_side_effect(
+        "config", lambda: "first", str, lambda old, new: old != new
+    )
+
+    assert result == "first"
+    dm.record_mutable_side_effect.assert_called_once_with(
+        "config", 0, dc.to_data(["first"])
+    )
+
+
+def test_mutable_side_effect_reuses_unchanged_value_without_marker():
+    ctx, dm = _make_ctx()
+    dc = _dc()
+    dm.mutable_side_effect_value.return_value = (3, dc.to_data(["stored"]), False)
+
+    result = ctx.mutable_side_effect(
+        "config", lambda: "candidate", str, lambda old, new: old == new
+    )
+
+    assert result == "stored"
+    dm.record_mutable_side_effect.assert_not_called()
+
+
+def test_mutable_side_effect_records_changed_value():
+    ctx, dm = _make_ctx()
+    dc = _dc()
+    dm.mutable_side_effect_value.return_value = (1, dc.to_data(["old"]), False)
+    dm.record_mutable_side_effect.return_value = dc.to_data(["new"])
+
+    result = ctx.mutable_side_effect(
+        "config", lambda: "new", str, lambda old, new: old != new
+    )
+
+    assert result == "new"
+    dm.record_mutable_side_effect.assert_called_once_with(
+        "config", 1, dc.to_data(["new"])
+    )
+
+
+def test_mutable_side_effect_replay_skips_callbacks_and_uses_history():
+    ctx, dm = _make_ctx(replay=True)
+    dc = _dc()
+    dm.mutable_side_effect_value.return_value = (2, dc.to_data(["history"]), True)
+    fn = MagicMock()
+    updated = MagicMock()
+    dm.record_mutable_side_effect.return_value = dc.to_data(["history"])
+
+    result = ctx.mutable_side_effect("config", fn, str, updated)
+
+    assert result == "history"
+    fn.assert_not_called()
+    updated.assert_not_called()
+    dm.record_mutable_side_effect.assert_called_once_with("config", 2, Payload())
+
+
+def test_mutable_side_effect_replay_without_recorded_value_fails():
+    ctx, dm = _make_ctx(replay=True)
+    dm.mutable_side_effect_value.return_value = (0, None, False)
+
+    with pytest.raises(ValueError, match="No recorded value"):
+        ctx.mutable_side_effect(
+            "config", lambda: "value", str, lambda old, new: old != new
+        )
+
+
+def test_mutable_side_effect_requires_id():
+    ctx, _ = _make_ctx()
+
+    with pytest.raises(ValueError, match="id must not be empty"):
+        ctx.mutable_side_effect("", lambda: "value", str, lambda old, new: old != new)
+
+
+def test_mutable_side_effect_module_level_dispatches_through_context():
+    ctx, dm = _make_ctx()
+    dc = _dc()
+    dm.mutable_side_effect_value.return_value = (0, None, False)
+    dm.record_mutable_side_effect.return_value = dc.to_data([7])
+
+    with ctx._activate():
+        result = workflow_module.mutable_side_effect(
+            "value", lambda: 7, int, lambda old, new: old != new
+        )
+
+    assert result == 7
+    dm.record_mutable_side_effect.assert_called_once()

--- a/tests/cadence/testing/test_workflow_environment.py
+++ b/tests/cadence/testing/test_workflow_environment.py
@@ -41,6 +41,24 @@ class ActivityWorkflow:
 
 
 @registry.workflow
+class MutableSideEffectWorkflow:
+    @workflow.run
+    async def run(self) -> tuple[int, int, int]:
+        values = iter((1, 1, 2))
+        return (
+            workflow.mutable_side_effect(
+                "config", lambda: next(values), int, lambda old, new: old != new
+            ),
+            workflow.mutable_side_effect(
+                "config", lambda: next(values), int, lambda old, new: old != new
+            ),
+            workflow.mutable_side_effect(
+                "config", lambda: next(values), int, lambda old, new: old != new
+            ),
+        )
+
+
+@registry.workflow
 class SignalWorkflow:
     def __init__(self) -> None:
         self._approved = False
@@ -159,6 +177,19 @@ async def test_start_simple_workflow(env: TestWorkflowEnvironment):
     assert execution.run_id
     assert env.is_workflow_completed(execution.workflow_id)
     assert env.get_workflow_result(str, execution.workflow_id) == "echo: world"
+
+
+@pytest.mark.asyncio
+async def test_mutable_side_effect_reuses_unchanged_value(env: TestWorkflowEnvironment):
+    execution = await env.client.start_workflow(
+        "MutableSideEffectWorkflow", task_list="tl"
+    )
+
+    assert env.get_workflow_result(tuple[int, int, int], execution.workflow_id) == (
+        1,
+        1,
+        2,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added mutable side-effect support, including marker metadata, replay caching, and public workflow APIs.
Mutable side-effect markers now use stable IDs derived from the side-effect ID and access count, rather than consuming the shared decision-ID sequence.

<!-- Tell your future self why have you made these changes -->
**Why?**
Mutable side effects record a value only when it changes while returning recorded values during replay. It allows use of function like random number without triggering non-determinism issue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**