### PR TITLE
fix(decision-worker): avoid missing decision task handling

### DIFF
--- a/cadence/worker/_decision_task_handler.py
+++ b/cadence/worker/_decision_task_handler.py
@@ -363,7 +363,7 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
                 task_token=task.task_token,
                 decisions=decision_result.decisions,
                 identity=self._identity,
-                return_new_decision_task=True,
+                return_new_decision_task=False,  # TODO: add optimization to handle the returned decision task if this is set to True
             )
 
             await self._client.worker_stub.RespondDecisionTaskCompleted(request)

--- a/cadence/worker/_decision_task_handler.py
+++ b/cadence/worker/_decision_task_handler.py
@@ -359,11 +359,12 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
         emitter = emitter if emitter is not None else self._metrics_emitter
         resp_start_ns = time.monotonic_ns()
         try:
+            should_return_new_decision_task = False # TODO: add optimization to handle the returned decision task if this is set to True
             request = RespondDecisionTaskCompletedRequest(
                 task_token=task.task_token,
                 decisions=decision_result.decisions,
                 identity=self._identity,
-                return_new_decision_task=False,  # TODO: add optimization to handle the returned decision task if this is set to True
+                return_new_decision_task=should_return_new_decision_task,  # TODO: add optimization to handle the returned decision task if this is set to True
             )
 
             await self._client.worker_stub.RespondDecisionTaskCompleted(request)
@@ -384,7 +385,7 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
                     else "unknown",
                     "started_event_id": task.started_event_id,
                     "decisions_count": len(decision_result.decisions),
-                    "return_new_decision_task": True,
+                    "return_new_decision_task": should_return_new_decision_task,
                     "task_token": task.task_token[:16].hex()
                     if task.task_token
                     else None,

--- a/cadence/worker/_decision_task_handler.py
+++ b/cadence/worker/_decision_task_handler.py
@@ -359,7 +359,7 @@ class DecisionTaskHandler(BaseTaskHandler[PollForDecisionTaskResponse]):
         emitter = emitter if emitter is not None else self._metrics_emitter
         resp_start_ns = time.monotonic_ns()
         try:
-            should_return_new_decision_task = False # TODO: add optimization to handle the returned decision task if this is set to True
+            should_return_new_decision_task = False  # TODO: add optimization to handle the returned decision task if this is set to True
             request = RespondDecisionTaskCompletedRequest(
                 task_token=task.task_token,
                 decisions=decision_result.decisions,

--- a/tests/cadence/worker/test_decision_task_handler.py
+++ b/tests/cadence/worker/test_decision_task_handler.py
@@ -399,7 +399,8 @@ class TestDecisionTaskHandler:
         assert isinstance(call_args, RespondDecisionTaskCompletedRequest)
         assert call_args.task_token == sample_decision_task.task_token
         assert call_args.identity == handler._identity
-        assert call_args.return_new_decision_task
+        # TODO: add optimization to handle the returned decision task if this is set to True
+        assert not call_args.return_new_decision_task
         assert len(call_args.decisions) == 2
 
     @pytest.mark.asyncio
@@ -417,7 +418,7 @@ class TestDecisionTaskHandler:
         call_args = handler._client.worker_stub.RespondDecisionTaskCompleted.call_args[
             0
         ][0]
-        assert call_args.return_new_decision_task
+        assert not call_args.return_new_decision_task
         assert len(call_args.decisions) == 0
 
     @pytest.mark.asyncio

--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from datetime import timedelta
 
@@ -17,6 +19,16 @@ from cadence.api.v1.service_workflow_pb2 import (
     TerminateWorkflowExecutionRequest,
 )
 from cadence.api.v1.common_pb2 import WorkflowExecution
+
+
+def unique_workflow_id(prefix: str) -> str:
+    """Build a workflow id that cannot collide with earlier runs.
+
+    These tests start workflows that no worker polls, so each execution stays
+    running until its timeout expires. A fixed id would clash with the run left
+    behind by a previous invocation against the same Cadence instance.
+    """
+    return f"{prefix}-{uuid.uuid4()}"
 
 
 @pytest.mark.usefixtures("helper")
@@ -70,7 +82,7 @@ async def test_workflow_stub_start_and_describe(helper: CadenceHelper):
         # Define workflow parameters
         workflow_type = "test-workflow-type-describe"
         task_list_name = "test-task-list-describe"
-        workflow_id = "test-workflow-describe-456"
+        workflow_id = unique_workflow_id("test-workflow-describe")
         execution_timeout = timedelta(minutes=5)
         task_timeout = timedelta(seconds=10)  # Default value
 
@@ -157,7 +169,7 @@ async def test_signal_workflow(helper: CadenceHelper):
     async with helper.client() as client:
         workflow_type = "test-workflow-signal"
         task_list_name = "test-task-list-signal"
-        workflow_id = "test-workflow-signal-789"
+        workflow_id = unique_workflow_id("test-workflow-signal")
         execution_timeout = timedelta(minutes=5)
         signal_name = "test-signal"
         signal_arg = {"action": "update", "value": 42}
@@ -218,7 +230,7 @@ async def test_workflow_id_reuse_policy_reject_duplicate(helper: CadenceHelper):
     async with helper.client() as client:
         workflow_type = "test-workflow-reuse-reject"
         task_list_name = "test-task-list-reuse-reject"
-        workflow_id = "test-workflow-reuse-reject-id"
+        workflow_id = unique_workflow_id("test-workflow-reuse-reject")
         execution_timeout = timedelta(minutes=5)
 
         first_execution = await client.start_workflow(
@@ -258,7 +270,7 @@ async def test_workflow_id_reuse_policy_terminate_if_running(helper: CadenceHelp
     async with helper.client() as client:
         workflow_type = "test-workflow-reuse-terminate"
         task_list_name = "test-task-list-reuse-terminate"
-        workflow_id = "test-workflow-reuse-terminate-id"
+        workflow_id = unique_workflow_id("test-workflow-reuse-terminate")
         execution_timeout = timedelta(minutes=5)
 
         first_execution = await client.start_workflow(
@@ -293,7 +305,7 @@ async def test_signal_with_start_workflow(helper: CadenceHelper):
     async with helper.client() as client:
         workflow_type = "test-workflow-signal-with-start"
         task_list_name = "test-task-list-signal-with-start"
-        workflow_id = "test-workflow-signal-with-start-123"
+        workflow_id = unique_workflow_id("test-workflow-signal-with-start")
         execution_timeout = timedelta(minutes=5)
         signal_name = "test-signal"
         signal_arg = {"data": "test-signal-data"}

--- a/tests/integration_tests/workflow/test_async_gather.py
+++ b/tests/integration_tests/workflow/test_async_gather.py
@@ -1,0 +1,98 @@
+import asyncio
+from datetime import timedelta
+
+import cadence.workflow as workflow
+
+from cadence import Registry
+from cadence.api.v1.history_pb2 import EventFilterType
+from cadence.api.v1.service_workflow_pb2 import (
+    GetWorkflowExecutionHistoryRequest,
+    GetWorkflowExecutionHistoryResponse,
+)
+from tests.integration_tests.helper import CadenceHelper, DOMAIN_NAME
+
+_TIMEOUT = timedelta(seconds=10)
+_FAN_OUT = 13
+
+reg = Registry()
+
+
+@reg.activity(name="async_gather.produce")
+def produce(count: int) -> list[int]:
+    return list(range(count))
+
+
+@reg.activity(name="async_gather.double")
+def double(value: int) -> int:
+    return value * 2
+
+
+@reg.workflow(name="AsyncGatherWorkflow")
+class AsyncGatherWorkflow:
+    @workflow.run
+    async def run(self, count: int) -> int:
+        values = await workflow.execute_activity(
+            "async_gather.produce",
+            list[int],
+            count,
+            start_to_close_timeout=_TIMEOUT,
+        )
+
+        doubled = await asyncio.gather(
+            *[
+                workflow.execute_activity(
+                    "async_gather.double",
+                    int,
+                    value,
+                    start_to_close_timeout=_TIMEOUT,
+                )
+                for value in values
+            ]
+        )
+
+        return sum(doubled)
+
+
+async def test_asyncio_gather(helper: CadenceHelper):
+    async with helper.worker(reg) as worker:
+        execution = await worker.client.start_workflow(
+            "AsyncGatherWorkflow",
+            _FAN_OUT,
+            task_list=worker.task_list,
+            execution_start_to_close_timeout=timedelta(seconds=100),
+        )
+
+        response: GetWorkflowExecutionHistoryResponse = await worker.client.workflow_stub.GetWorkflowExecutionHistory(
+            GetWorkflowExecutionHistoryRequest(
+                domain=DOMAIN_NAME,
+                workflow_execution=execution,
+                wait_for_new_event=True,
+                history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_CLOSE_EVENT,
+                skip_archival=True,
+            )
+        )
+
+        expected = sum(value * 2 for value in range(_FAN_OUT))
+        assert (
+            str(expected)
+            == response.history.events[
+                -1
+            ].workflow_execution_completed_event_attributes.result.data.decode()
+        )
+
+        all_history: GetWorkflowExecutionHistoryResponse = await worker.client.workflow_stub.GetWorkflowExecutionHistory(
+            GetWorkflowExecutionHistoryRequest(
+                domain=DOMAIN_NAME,
+                workflow_execution=execution,
+                history_event_filter_type=EventFilterType.EVENT_FILTER_TYPE_ALL_EVENT,
+                skip_archival=True,
+            )
+        )
+
+        timed_out = [
+            event
+            for event in all_history.history.events
+            if event.WhichOneof("attributes")
+            == "decision_task_timed_out_event_attributes"
+        ]
+        assert not timed_out, f"Decision task(s) timed out: {timed_out}"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* When decision worker respond decision completed, set return_new_decision_task flag to False
* fix integration test when --keep-cadence-live flag is set locally for easier testing

<!-- Tell your future self why have you made these changes -->
**Why?**

return_new_decision_task flag controls whether responddecisioncompletetask would return a new decision. It could happen when 
1. server enable the feature
2. during decision task processing there is a buffered activity completed event. It's very common when there are concurrency activity executions
3. return_new_decision_task is set to true. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Added async gather integration test to avoid regression.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**